### PR TITLE
2.4.1 missed issue

### DIFF
--- a/news/_posts/2015-11-27-akka-2.4.1-released.md
+++ b/news/_posts/2015-11-27-akka-2.4.1-released.md
@@ -16,6 +16,7 @@ This release contains a few important fixes and improvements:
 * Using the distributed data mode the sharding coordinator updates correctly after leader downing
 * Possibility to provide a custom supervision strategy for the BackOffSupervisor
 * Problem with split brain on cluster startup under some circumstances solved
+* A new `Supervisor` that supports exponential restart back-off semantics for actors regardless of their lifecycle model (the BackoffSupervisor overloads the meaning of self-termination)
 
 The complete list of closed tickets can be found in the [2.4.1 github issues milestone](https://github.com/akka/akka/issues?q=milestone%3A2.4.1).
 


### PR DESCRIPTION
Missed out on the TransparentExponentialBackoffSupervisor in the initial announcement of 2.4.1