### PR TITLE
Fixed menu links and icons on 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -50,9 +50,9 @@
         <a href="/"><img src="/resources/images/logo-small.png" /></a>
       </div>
       <ul class="nav">
-        <li><a href="{{ site.baseurl }}/docs/">Documentation</a></li>
-        <li><a href="{{ site.baseurl }}/downloads/">Download</a></li>
-        <li><a href="{{ site.baseurl }}/get-involved/">Get Involved</a></li>
+        <li><a href="/docs/">Documentation</a></li>
+        <li><a href="/downloads/">Download</a></li>
+        <li><a href="/get-involved/">Get Involved</a></li>
       </ul>
     </div>
   </div>
@@ -94,11 +94,11 @@
       <li><a href="http://akka.io/downloads">Downloads</a></li>
       <li>
       	<a href="http://akka.io/news">News</a>
-        <span class="rss-icon"><a href="https://github.com/akka/akka.github.com/commits/master/news/_posts.atom"><img src="{{ site.baseurl }}/resources/images/rss.png" height="13px" width="13px" /></a></span>
+        <span class="rss-icon"><a href="https://github.com/akka/akka.github.com/commits/master/news/_posts.atom"><img src="/resources/images/rss.png" height="13px" width="13px" /></a></span>
       </li>
       <li>
           <a href="http://blog.akka.io">Blog</a>
-          <span class="rss-icon"><a href="http://blog.akka.io/rss"><img src="{{ site.baseurl }}/resources/images/rss.png" height="13px" width="13px" /></a></span>
+          <span class="rss-icon"><a href="http://blog.akka.io/rss"><img src="/resources/images/rss.png" height="13px" width="13px" /></a></span>
       </li>
     </ul>
     <ul>
@@ -112,7 +112,7 @@
       <li><a href="http://typesafe.com/products/typesafe-subscription">Commercial Support</a></li>
       <li><a href="http://akka.io/team">Team</a></li>
       <li><a href="mailto:info@typesafe.com">Contact</a></li>
-    </ul>
+    </ul
     <ul>
       <li><img src="/resources/images/watermark.png" align="center"/></li>
     </ul>


### PR DESCRIPTION
Couldn't figure out how (if possible) to get the jekyll placeholder to work in the 404 page so replaced with site-relative links, which worked locally with jekyll.