### PR TITLE
Move akka-http-testkit to the rest of HTTP deps

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -37,7 +37,6 @@
        "akka-cluster-tools",
        "akka-contrib",
 
-       "akka-http-testkit",
        "akka-multi-node-testkit",
        "akka-osgi",
        "akka-persistence",
@@ -60,6 +59,7 @@
        "akka-http-experimental",
        "akka-http-jackson-experimental",
        "akka-http-spray-json-experimental",
+       "akka-http-testkit",
        "akka-http-xml-experimental"
      ].map(makeModuleDescription(akkaHttpVersion))
 


### PR DESCRIPTION
It seems the `akka-http-teskit` should've been moved with [the rest](https://github.com/akka/akka.github.com/commit/4896ac0f82d5af5f0a87905bbc0f391b6709e919) of `akka-http` dependencies to the separate list, but wasn't.

Noticed by Gavin Baumanis (@thespidernet ?) on the akka-user mailing list.