### PR TITLE
Remove second 'Scala' from the title on the docs index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ title: Akka Documentation
 
 ## Release Versions
 
-### Akka 2.4.12 (current stable release) for Scala Scala 2.11 / 2.12.0-RC2 and Java 8+
+### Akka 2.4.12 (current stable release) for Scala 2.11 / 2.12.0-RC2 and Java 8+
 
 * Akka Documentation
 


### PR DESCRIPTION
The commit that introduced the second “Scala” was more than year ago, so I'm slightly worried it's not a typo but some sort of unknown to me convention for how you write Scala version ranges in titles or something. :) I'm sorry for bothering you if it is.