### PR TITLE
Fix links on /blog/tags page (for subpath installations)

### DIFF
--- a/blog/tags.md
+++ b/blog/tags.md
@@ -17,6 +17,7 @@ group: navigation
 		{% for tag in tags_list %}
 		<h2 id="{{ tag[0] }}-ref">{{ tag[0] | capitalize }}</h2>
   		<ul>
+		    {% assign BASE_PATH = site.baseurl %}
 			{% assign pages_list = tag[1] | sort "date" %}
     		{% include JB/pages_list %}
   		</ul>


### PR DESCRIPTION
Not sure what JB is and how it is configured but it doesn't work automatically
for some reason.