### PR TITLE
Ignore bundler install output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ _site
 # ruby/jekyll
 Gemfile.lock
 .jekyll-metadata
+vendor
+.bundle

--- a/_config.yml
+++ b/_config.yml
@@ -17,6 +17,7 @@ sass:
 
 exclude:
 - README
+- vendor
 
 defaults:
 -


### PR DESCRIPTION
Bundler recommends to install stuff to the project's local directory:

    bundle install --path vendor/bundle

But after that running jekyll fails, because it can not parse blog entries from the `vendor` directory. This adds ignores to the git and jekyll configs to ignore these.