### PR TITLE
Fix headers in Akka HTTP 10.0.7 announcement

### DIFF
--- a/blog/_posts/2017-05-25-akka-http-10.0.7-released.md
+++ b/blog/_posts/2017-05-25-akka-http-10.0.7-released.md
@@ -13,13 +13,13 @@ We are proud to announce Akka Http 10.0.7, which is the seventh release of the A
 maintenance release that contains several maintenance fixes, improvements and features that are a result of our ongoing 
 collaboration with the Play team towards making Akka HTTP the default backend in Play’s upcoming major release.
 
-### Notable changes
+## Notable changes
 
 A total 29 issues were closed since 10.0.6. Out of those, the most notable ones are listed below.
 
 You can view the complete list of closed issues can be found on the [10.0.7](https://github.com/akka/akka-http/milestone/25?closed=1) milestone on github.
 
-**New documentation theme (aligned with new theme in Akka)**
+### New documentation theme (aligned with new theme in Akka)
 
 Today, as follow up to yesterday's [Akka 2.5.2 release](http://akka.io/blog/news/2017/05/24/akka-2.5.2-released), 
 Akka HTTP also moves to using the new documentation theme. This is the first step towards even more simplification
@@ -30,45 +30,45 @@ We are aware that the search functionality is currently non-operational, and are
 The indexing mechanism of the 3rd party search engine is not yet able to work with our new structure - please
 be patient for a little while while we resolve this issue.
 
-**New Seed Templates for Akka HTTP Apps**
+### New Seed Templates for Akka HTTP Apps
 
 We prepared new seed templates for starting out with Akka HTTP using the [Java DSL](https://github.com/akka/akka-http-java-seed.g8)
 as well as [Scala DSL](https://github.com/akka/akka-http-scala-seed.g8). By using the sbt new command one can now easily get a
 small sample project to easily get started with your first Akka HTTP app. More instructions on the seed template pages.
 
-**New Path Directive ****ignoreTrailingSlash**
+### New Path Directive `ignoreTrailingSlash`
 
 Akka HTTP treats differently by default a route that ends with slash (/) than one that doesn't. From this version on, 
 users who don't want to have this distinction, can use a new Path Directive called ignoreTrailingSlash. This route, will 
 retry its inner route with and without a trailing slash. If you want to know more about this feature, please check the 
 documentation pages for Scala and Java API.
 
-#### List of Changes
+## List of Changes
 
-**Improvements**
+### Improvements
 
-**akka-http**
+#### akka-http
 
 * Added new Path Directive ignoreTrailingSlash ([#880](https://github.com/akka/akka-http/issues/880))
 * Prepared new seed templates for Akka HTTP apps (for both [Java DSL](https://github.com/akka/akka-http-java-seed.g8) and [Scala DSL](https://github.com/akka/akka-http-scala-seed.g8))  ([#1137](https://github.com/akka/akka-http/issues/1137) & [#1055](https://github.com/akka/akka-http/issues/1055))
 * Migrated to the new docs theme (same as Akka) ([#1129](https://github.com/akka/akka-http/issues/1129))
 * (ApiMayChange) `HttpApp#route` method was renamed to `routes` to highlight it is "all the routes" ([#953](https://github.com/akka/akka-http/issues/953))
 
-**akka-http2-support**
+#### akka-http2-support
 
 * Synthetic Remote-Address header setting is now honored in HTTP2 server blueprint ([#1088](https://github.com/akka/akka-http/issues/1088))
 
-#### Bug Fixes
+### Bug Fixes
 
-**General**
+#### General
 
 * OSGi Import-Package ranges have been fixed to allow Akka 2.5.x [#1097](https://github.com/akka/akka-http/issues/1097)
 
-**akka-http-core**
+#### akka-http-core
 
 * Dates in RFC1123 format with single-digit-day are now properly parsed [#1110](https://github.com/akka/akka-http/issues/1110) 
  
-### Compatibility notes
+## Compatibility notes
 
 This version is compatible with Akka 2.4.x as well as the current 2.5.1, so we encourage you to use Akka 2.5 with this version, as the new completely redesigned materializer in Akka Streams can result in various performance and memory usage improvements across the board.
 


### PR DESCRIPTION
Right now it looks a bit unstructured.