### PR TITLE
Gradle and Maven spelled with upper-case first letter

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -79,8 +79,8 @@ redirect_from: "/downloads"
          <div class="docTabPanel">
            <ul class="tabPanelList">
              <li rel="1-panel-sbt" class="active">sbt</li>
-             <li rel="1-panel-gradle">gradle</li>
-             <li rel="1-panel-maven">maven</li>
+             <li rel="1-panel-gradle">Gradle</li>
+             <li rel="1-panel-maven">Maven</li>
            </ul>
            <div id="1-panel-sbt" class="tabPanel active">
 
@@ -133,8 +133,8 @@ redirect_from: "/downloads"
         <div class="docTabPanel">
           <ul class="tabPanelList">
             <li rel="2-panel-sbt" class="active">sbt</li>
-            <li rel="2-panel-gradle">gradle</li>
-            <li rel="2-panel-maven">maven</li>
+            <li rel="2-panel-gradle">Gradle</li>
+            <li rel="2-panel-maven">Maven</li>
           </ul>
           <div id="2-panel-sbt" class="tabPanel active">
 <pre><div class="copyBtn hidden" title="copy to clipboard"></div>libraryDependencies ++= Seq( 
@@ -185,8 +185,8 @@ redirect_from: "/downloads"
         <div class="docTabPanel">
           <ul class="tabPanelList">
             <li rel="3-panel-sbt" class="active">sbt</li>
-            <li rel="3-panel-gradle">gradle</li>
-            <li rel="3-panel-maven">maven</li>
+            <li rel="3-panel-gradle">Gradle</li>
+            <li rel="3-panel-maven">Maven</li>
           </ul>
           <div id="3-panel-sbt" class="tabPanel active">
 <pre><div class="copyBtn hidden" title="copy to clipboard"></div>libraryDependencies ++= Seq(
@@ -239,8 +239,8 @@ redirect_from: "/downloads"
         <div class="docTabPanel">
           <ul class="tabPanelList">
             <li rel="4-panel-sbt" class="active">sbt</li>
-            <li rel="4-panel-gradle">gradle</li>
-            <li rel="4-panel-maven">maven</li>
+            <li rel="4-panel-gradle">Gradle</li>
+            <li rel="4-panel-maven">Maven</li>
           </ul>
           <div id="4-panel-sbt" class="tabPanel active">
 <pre><div class="copyBtn hidden" title="copy to clipboard"></div>libraryDependencies += 
@@ -280,8 +280,8 @@ redirect_from: "/downloads"
         <div class="docTabPanel">
           <ul class="tabPanelList">
             <li rel="5-panel-sbt" class="active">sbt</li>
-            <li rel="5-panel-gradle">gradle</li>
-            <li rel="5-panel-maven">maven</li>
+            <li rel="5-panel-gradle">Gradle</li>
+            <li rel="5-panel-maven">Maven</li>
           </ul>
           <div id="5-panel-sbt" class="tabPanel active">
 <pre><div class="copyBtn hidden" title="copy to clipboard"></div>libraryDependencies += 
@@ -321,8 +321,8 @@ redirect_from: "/downloads"
            <div class="docTabPanel">
              <ul class="tabPanelList">
                <li rel="7-panel-sbt" class="active">sbt</li>
-               <li rel="7-panel-gradle">gradle</li>
-               <li rel="7-panel-maven">maven</li>
+               <li rel="7-panel-gradle">Gradle</li>
+               <li rel="7-panel-maven">Maven</li>
              </ul>
              <div id="7-panel-sbt" class="tabPanel active">
 <pre><div class="copyBtn hidden" title="copy to clipboard"></div>libraryDependencies += 
@@ -381,8 +381,8 @@ redirect_from: "/downloads"
           <div class="docTabPanel">
             <ul class="tabPanelList">
               <li rel="8-panel-sbt" class="active">sbt</li>
-              <li rel="8-panel-gradle">gradle</li>
-              <li rel="8-panel-maven">maven</li>
+              <li rel="8-panel-gradle">Gradle</li>
+              <li rel="8-panel-maven">Maven</li>
             </ul>
             <div id="8-panel-sbt" class="tabPanel active">
 <pre><div class="copyBtn hidden" title="copy to clipboard"></div>libraryDependencies +=


### PR DESCRIPTION
AFAICS you wanted to make these more consistent in the docs @raboof, so applying the same here