### PR TITLE
Release 2.5.5 with JDK9 and juc.Flow support!

### DIFF
--- a/blog/_posts/2017-09-28-akka-2.5.5-released.md
+++ b/blog/_posts/2017-09-28-akka-2.5.5-released.md
@@ -26,7 +26,7 @@ The most important features are:
     * and the Receptionist [#23634](https://github.com/akka/akka/issues/23634)
 * First release of [Multi-DC Clustering](https://doc.akka.io/docs/akka/current/scala/cluster-dc.html) (preview)
 
-A total of 99 issues were closed since 2.5.4. The complete list can be found on the [2.5.5](https://github.com/akka/akka/milestone/118?closed=1) milestone on github.
+A total of 100 (*sic!*) issues were closed since 2.5.4. The complete list can be found on the [2.5.5](https://github.com/akka/akka/milestone/118?closed=1) milestone on github.
 
 ## Request for feedback of Akka Typed APIs
 
@@ -47,7 +47,7 @@ Starting today, it is possible to consume/expose Akka Streams directly as *j.u.c
 
 ## Credits
 
-For this release we had the help of 33 committers and contributors – thank you all very much!
+For this release we had the help of 34 committers and contributors – thank you all very much!
 
 ```
 commits  added  removed
@@ -80,6 +80,7 @@ commits  added  removed
       1      2        2 Lucian Enache
       1      2        2 Szymon Chojnacki
       1      2        1 Lukas Phaf
+      1      1        1 novacekm
       1      1        1 petermz
       1      1        1 Philippus Baalman
       1      1        1 Arun Manivannan

--- a/blog/_posts/2017-09-28-akka-2.5.5-released.md
+++ b/blog/_posts/2017-09-28-akka-2.5.5-released.md
@@ -11,11 +11,11 @@ tags: [releases]
 Dear hakkers,
 
 We are pleased to announce a new patch release of Akka 2.5. 
-Other than the usual hardening and maintanance work, during this period we made a lot of progress on multiple very important new features which we’re very proud to release today.
+Other than the usual hardening and maintenance work, during this period we made a lot of progress on multiple very important new features which we’re very proud to release today.
 
 The most important features are:
 
-* Support for Java 9 across the board
+* Support for Java 9 across the board (while maintaining Java 8 support)
 * Support for [java.util.concurrent.Flow](http://download.java.net/java/jdk9/docs/api/java/util/concurrent/Flow.html) interfaces in Akka Streams [#23578](https://github.com/akka/akka/issues/23578) 
 * Akka Typed API previews for: 
     * Persistence [#22273](https://github.com/akka/akka/issues/22273) [#23693](https://github.com/akka/akka/issues/23693) 
@@ -30,13 +30,13 @@ A total of 99 issues were closed since 2.5.4. The complete list can be found on 
 
 ## Request for feedback of Akka Typed APIs
 
-Please note that all the Akka Typed APIs (persistence, cluster, ...) remain "[ApiMayChange](https://doc.akka.io/docs/akka/2.5.4/scala/common/may-change.html)", 
+Please note that all the Akka Typed APIs (persistence, cluster, ...) remain "[ApiMayChange](https://doc.akka.io/docs/akka/current/scala/common/may-change.html)", 
 as we continue to gather feedback and finalize those APIs over the coming months. We’d like to encourage you to try them out and provide feedback in case you 
 encounter some missing or confusing functionality. 
 
 These new APIs do not yet have a full-blown documentation, however we will introduce all the APIs in a fresh blog post series, 
-begining with the [Typed Akka Cluster API post](http://akka.io/blog/2017/09/28/typed-cluster) published *right now*, where 
-we introduce these Typed APIs–more posts will follow, so please keep an eye on our [blog](http://akka.io/blog/) and [twitter](https://twitter.com/akkateam)!
+begining with the [Typed Akka Cluster API post](https://akka.io/blog/2017/09/28/typed-cluster) published *right now*, where 
+we introduce these Typed APIs–more posts will follow, so please keep an eye on our [blog](https://akka.io/blog/) and [twitter](https://twitter.com/akkateam)!
 
 ## JDK9 and java.util.concurrent.Flow.* compatibility
 

--- a/blog/_posts/2017-09-28-akka-2.5.5-released.md
+++ b/blog/_posts/2017-09-28-akka-2.5.5-released.md
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: Akka HTTP 2.5.5 Released
+title: Akka HTTP 2.5.5 Released – with JDK9 and j.u.c.Flow support
 author: Konrad 'ktoso' Malawski
 short: We are happy to announce a new patch release of Akka 2.5
 category: news
 tags: [releases]
 ---
-# ANNOUNCE: Akka 2.5.5
+# ANNOUNCE: Akka 2.5.5 – with JDK9 and j.u.c.Flow support
 
 Dear hakkers,
 

--- a/blog/_posts/2017-09-28-akka-2.5.5-released.md
+++ b/blog/_posts/2017-09-28-akka-2.5.5-released.md
@@ -1,0 +1,94 @@
+---
+layout: post
+title: Akka HTTP 2.5.5 Released
+author: Konrad 'ktoso' Malawski
+short: We are happy to announce a new patch release of Akka 2.5
+category: news
+tags: [releases]
+---
+# ANNOUNCE: Akka 2.5.5
+
+Dear hakkers,
+
+We are pleased to announce a new patch release of Akka 2.5. 
+Other than the usual hardening and maintanance work, during this period we made a lot of progress on multiple very important new features which we’re very proud to release today.
+
+The most important features are:
+
+* Support for Java 9 across the board
+* Support for [java.util.concurrent.Flow](http://download.java.net/java/jdk9/docs/api/java/util/concurrent/Flow.html) interfaces in Akka Streams [#23578](https://github.com/akka/akka/issues/23578) 
+* Akka Typed API previews for: 
+    * Persistence [#22273](https://github.com/akka/akka/issues/22273) [#23693](https://github.com/akka/akka/issues/23693) 
+    * Cluster [#21226](https://github.com/akka/akka/issues/21226) 
+    * Cluster Singleton [#23613](https://github.com/akka/akka/pull/23613) 
+    * Cluster Sharding [#23698](https://github.com/akka/akka/issues/23698)
+    * Distributed Data [#23664](https://github.com/akka/akka/issues/23664) 
+    * and the Receptionist [#23634](https://github.com/akka/akka/issues/23634)
+* First release of [Multi-DC Clustering](https://doc.akka.io/docs/akka/current/scala/cluster-dc.html) (preview)
+
+A total of 99 issues were closed since 2.5.4. The complete list can be found on the [2.5.5](https://github.com/akka/akka/milestone/118?closed=1) milestone on github.
+
+## Request for feedback of Akka Typed APIs
+
+Please note that all the Akka Typed APIs (persistence, cluster, ...) remain "[ApiMayChange](https://doc.akka.io/docs/akka/2.5.4/scala/common/may-change.html)", 
+as we continue to gather feedback and finalize those APIs over the coming months. We’d like to encourage you to try them out and provide feedback in case you 
+encounter some missing or confusing functionality. 
+
+These new APIs do not yet have a full-blown documentation, however we will introduce all the APIs in a fresh blog post series, 
+begining with the [Typed Akka Cluster API post](http://akka.io/blog/2017/09/28/typed-cluster) published *right now*, where 
+we introduce these Typed APIs–more posts will follow, so please keep an eye on our [blog](http://akka.io/blog/) and [twitter](https://twitter.com/akkateam)!
+
+## JDK9 and java.util.concurrent.Flow.* compatibility
+
+This release also marks the first Akka release which is both Java 9 *compatible*, as well as provides support for the new 
+[`java.util.concurrent.Flow.*`](http://download.java.net/java/jdk9/docs/api/java/util/concurrent/Flow.html) interfaces, which we are incredibly proud to see shipping in the JDK – as they are the result of the [Reactive Streams](http://reactive-streams.org) initiative that we co-lead and intensely participated in over the last years. The* `j.u.c.Flow` interfaces are 1:1 semantically equivalent to their Reactive Streams counterparts, and adhere to the same specification, and can be tested using the same, freely available, [Technology Compatibility Kit](https://github.com/reactive-streams/reactive-streams-jvm/tree/v1.0.1/tck).
+
+Starting today, it is possible to consume/expose Akka Streams directly as *j.u.c.Flow* types, using the akka.stream.[[javadsl](https://github.com/akka/akka/blob/master/akka-stream/src/main/java-jdk9-only/akka/stream/javadsl/JavaFlowSupport.java) | [scaladsl](https://github.com/akka/akka/blob/master/akka-stream/src/main/scala-jdk9-only/akka/stream/scaladsl/JavaFlowSupport.scala)].JavaFlowSupport Sinks and Sources. No additional dependency has to be added to make use of these types, other than making sure to compile and run using JDK9. Users of previous versions of Java will not be able to compile or use those types, and are recommended to stick to Akka Streams or Reactive Streams interfaces in case a need for inter-operability between libraries arises.
+
+## Credits
+
+For this release we had the help of 33 committers and contributors – thank you all very much!
+
+```
+commits  added  removed
+     44   4769     1571 Patrik Nordwall
+     19   4629      637 Johan Andrén
+     18   1019      247 Arnout Engelen
+     14   2940      413 Konrad `ktoso` Malawski
+      6    982      383 Johannes Rudolph
+      5     21       27 Christopher Batey
+      4    329      184 Alexander Golubev
+      3    118      110 Guido Medina
+      3    150        7 Martynas Mickevičius
+      3     41        9 Sebastian Harko
+      2     12       17 Josep Prat
+      2      2        2 SirMullich
+      1    173      478 Richard Imaoka
+      1    459        4 Nikos Nakas
+      1    162       24 Rafał Sumisławski
+      1     96       41 László van den Hoek
+      1     64        3 Kirill Yankov
+      1     59        1 Heiko Seeberger
+      1     55        2 Cause Chung
+      1     35        7 sebastian.harko
+      1      1       25 Atiq Sayyed
+      1     16        1 gosubpl
+      1      5        1 Kamil Kafara
+      1      3        2 Nadav Wiener
+      1      2        2 Jimin Hsieh
+      1      3        1 Will Sargent
+      1      2        2 Lucian Enache
+      1      2        2 Szymon Chojnacki
+      1      2        1 Lukas Phaf
+      1      1        1 petermz
+      1      1        1 Philippus Baalman
+      1      1        1 Arun Manivannan
+      1      1        1 Kyle Song
+      1      1        1 Changwon Choe
+      1      0        1 Andrea Peruffo
+```
+
+Happy hakking!
+
+– The Akka Team
+


### PR DESCRIPTION
Please merge https://github.com/akka/akka.github.com/pull/463 before this one, as we point to it in this news item
