### PR TITLE
Releasing Akka HTTP 10.1.0-RC1

### DIFF
--- a/blog/_posts/2017-12-22-akka-http-10.1.0-RC1-released.md
+++ b/blog/_posts/2017-12-22-akka-http-10.1.0-RC1-released.md
@@ -1,0 +1,130 @@
+---
+layout: post
+title: Akka HTTP 10.1.0-RC1 Released
+author: Johannes Rudolph
+short: We are happy to announce the first release candidate of the new upcoming minor release of Akka HTTP, 10.1.0-RC1
+category: news
+tags: [releases]
+---
+
+Dear hakkers,
+
+as a special present for the holidays, we are happy to announce Akka Http 10.1.0-RC1, the first release candidate of the
+upcoming minor release series of Akka HTTP. The goal for this upcoming minor release is to be able to cleanup some technical
+debt and make the switch to Akka 2.5 which in the future will enable us to make us of features only available in Akka 2.5.
+Also, the new client pool implementation is now the default.
+
+We wish everyone happy holidays and a happy new year! Thanks to all our users and contributors for all the great feedback
+and collaboration!
+
+The most important changes for this release are
+
+ * Removing support for Akka 2.4.x which is at its end-of-life with the end of 2017. In the future, this will allow us
+   to make use of features that only Akka 2.5 supports.
+ * Removing methods that have been deprecated during the life-time of Akka HTTP 10.0.x. For now, methods only deprecated
+   in the last release of Akka HTTP, 10.0.11, are not yet removed to allow for a smooth transition.
+ * The new client pool implementation introduced in 10.0.11 is now the default. Please try it out and provide feedback
+   during the RC period of this release so we can iron out any problems we may have missed initially.
+ * Documentation has now ~almost~ completely been consolidated between Scala and Java pages. Hundreds of directive
+   documentation pages have been merged in a tireless effort by [@jonas](https://github.com/jonas),
+   [@jlprat](https://github.com/jlprat), and Akka team's [@raboof](https://github.com/raboof). We also restructured
+   the table of contents to improve the documentation browsing experience.
+
+### Akka is not an explicit dependency any more / Removal of Akka 2.4 support
+
+Akka HTTP 10.0.x has always supported Akka 2.5, while allowing users to still remain on Akka 2.4.x if they choose to do so.
+By now Akka 2.4 has reached its end of life. Therefore, Akka HTTP 10.1.x only supports Akka 2.5
+(and future versions during the life of Akka HTTP 10.1.x) so we will be able to make of features only provided by Akka 2.5.
+
+Using Akka HTTP with Akka 2.5 used to be
+a bit confusing, because Akka HTTP explicitly depended on Akka 2.4. Trying to use it together with Akka 2.5,
+running an Akka HTTP application could fail with class loading issues if you forgot to add a dependency to
+both `akka-actor` *and* `akka-stream` of the same version. For that reason, we changed the policy not to depend on `akka-stream`
+explicitly any more but mark it as a `provided` dependency in our build. That means that you will have to *always* add
+a manual dependency to `akka-stream`. Please make sure you have chosen and added a dependency to `akka-stream` when
+updating to the new version. (Veterans may remember this policy from spray.)
+
+### Deprecation Removals
+
+Methods were removed that have been deprecated during the life-time of Akka HTTP 10.0.x. Methods that were only deprecated
+in the last release of Akka HTTP, 10.0.11, are not yet removed to allow for a smooth transition. In general, our guarantee
+for minor release updates is that code that compiled on the latest version of the previous minor release (10.0.11 in this case)
+should be both source and binary compatible with the latest version of the current minor release. We might make
+exceptions to the rule for cases where the maintenance burden seems greater than the risk of breaking major users / third-party
+libraries. We'll treat any other binary incompatibilities as regressions.
+
+### New client pool implementation is now the default
+
+The new client pool implementation introduced in 10.0.11 is now the default. In this release we fixed several bugs in the
+new client pool implementation and we want to foster its adoption. Please try it out and provide feedback
+during the RC period of this release so we can iron out any problems we may have missed initially.
+You can still fall back to the old implementation by setting `akka.http.host-connection-pool.pool-implementation = legacy`.
+
+### List of changes
+
+#### Improvements
+
+##### akka-http-core
+
+ * Add missing javadsl model bits and pieces ([#1679](https://github.com/akka/akka-http/issues/1679))
+ * New client pool is now the default
+ * Several improvements and fixes to new client pool implementation
+ * Methods deprecated before (but not including) 10.0.11 were removed
+ * Add convenience Java DSL `Http.cachedHostConnectionPoolHttps` ([#1644](https://github.com/akka/akka-http/issues/1644))
+ * Add Retry-After header model ([#1554](https://github.com/akka/akka-http/issues/1554))
+ * Adding percent encoding length check for Path.Uri ([#1553](https://github.com/akka/akka-http/issues/1553))
+
+##### akka-http
+
+ * Methods deprecated before (but not including) 10.0.11 were removed
+
+#### akka-http-caching
+
+ * Add non-lambda-capturing getOrLoad method to Cache ([#1536](https://github.com/akka/akka-http/issues/1536))
+
+#### Documentation
+
+ * Almost the complete directive documentation has now been consolidated between Java and Scala. More than hundred
+   pages have been simplified like this.
+ * The top-level documentation structure has been clarified.
+
+#### Bug Fixes
+
+##### akka-http-core
+
+ * Fix return type for `withStatus` methods to return proper scaladsl types ([#1623](https://github.com/akka/akka-http/issues/1623))
+ * Fix "Cannot push port ... twice" in NewHostConnectionPool ([#1610](https://github.com/akka/akka-http/issues/1610)) and several other fixes
+
+##### Documentation
+
+ * Fix generation/publication of javadoc (10.0.11 javadoc link pointed to scaladoc instead)
+
+
+## Credits
+
+A total of 22 issues were closed since 10.0.11.
+
+The complete list of closed issues can be found on the [10.1.0-RC1 milestone](https://github.com/akka/akka-http/milestone/26?closed=1) milestones on GitHub.
+
+For this release we had the help of 13 contributors – thank you all very much!
+
+```
+commits added removed
+   44    4841    4860 Arnout Engelen
+   32    1196     613 Johannes Rudolph
+   22     720    2789 Josep Prat
+    3     122     349 Jonas Fonseca
+    2      28      17 Pavel Boldyrev
+    1       6       4 Johan Andrén
+    1     128       4 Martynas Mickevičius
+    1     111       1 Ivano Pagano
+    1      21       1 Kentaro Maeda
+    1       1       1 Philippus Baalman
+    1       2       0 Jimin Hsieh
+    1       1       1 David Francoeur
+    1      23       2 Catalin Ursachi
+```
+
+Happy hakking and happy holidays to everyone!
+
+– The Akka Team


### PR DESCRIPTION
Only merge after the actual release.

Release stats should be updated once again with the final numbers.

