### PR TITLE
Fix typo in Akka HTTP 10.1 RC1 post

### DIFF
--- a/blog/_posts/2017-12-22-akka-http-10.1.0-RC1-released.md
+++ b/blog/_posts/2017-12-22-akka-http-10.1.0-RC1-released.md
@@ -11,7 +11,7 @@ Dear hakkers,
 
 as a special present for the holidays, we are happy to announce Akka Http 10.1.0-RC1, the first release candidate of the
 upcoming minor release series of Akka HTTP. The goal for this upcoming minor release is to be able to cleanup some technical
-debt and make the switch to Akka 2.5 which in the future will enable us to make us of features only available in Akka 2.5.
+debt and make the switch to Akka 2.5 which in the future will enable us to make use of features only available in Akka 2.5.
 Also, the new client pool implementation is now the default.
 
 We wish everyone happy holidays and a happy new year! Thanks to all our users and contributors for all the great feedback


### PR DESCRIPTION
Note also that there’s also a redirect missing from /news/... -> /blog/news/...