### PR TITLE
Update link to 'Actor model'

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@ description: Build powerful reactive, concurrent, and distributed applications i
             <a href="{{ site.baseurl }}/try-akka/" class="btn">Try Akka</a>
             
             <p class="heroSmall">
-                Akka is <i>the</i> implementation of the <a href="http://doc.akka.io/docs/akka/current/scala/guide/introduction.html#what-is-the-actor-model-">Actor Model</a> on the JVM.
+                Akka is <i>the</i> implementation of the <a href="https://doc.akka.io/docs/akka/current/guide/actors-motivation.html">Actor Model</a> on the JVM.
             </p>
         </div>
         <div class="sixcol">


### PR DESCRIPTION
The anchor doesn't exist any more after https://github.com/akka/akka/pull/23210, this seems like the best alternative. Maybe @raboof can check it.