### PR TITLE
update latest akka-http version

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,6 @@ defaults:
     # versions.json will be updated as long as the changes here are patch versions, for minor and major it needs to
     # be updated manually
     current_akka_version: 2.5.11
-    current_akka_http_version: 10.0.11
+    current_akka_http_version: 10.1.0
     previous_akka_version: 2.4.20
     current_java_scala_version: 2.12 # used for deps for Java


### PR DESCRIPTION
Hi, 

according to [akka-http-10.1.0-released](https://akka.io/blog/news/2018/03/08/akka-http-10.1.0-released), I guess this needs to be updated, right?

I hope this changes the version on this page: https://akka.io/docs/ (see akka-http).

Matthias