### PR TITLE
Fix language select box breaking out of its container on small screens

### DIFF
--- a/resources/stylesheets/sass/views/_docs.scss
+++ b/resources/stylesheets/sass/views/_docs.scss
@@ -38,7 +38,7 @@
         #search-ref-docs {
           display: flex;
           flex-direction: row;
-          flex-wrap: nowrap;
+          flex-wrap: wrap;
           justify-content: space-between;
           align-items: center;
           @include single-column {


### PR DESCRIPTION
this is noticeable on an iPhone 5 f.e.:
<img width="349" alt="schermafdruk 2018-03-23 21 39 47" src="https://user-images.githubusercontent.com/1923596/37852419-ca7e0570-2ee2-11e8-8a98-6c68fc515287.png">

I think this fixes it, but I'm no frontend expert so please check thoroughly :)