### PR TITLE
Fix scala 2.12.7 api doc links

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -71,7 +71,7 @@ redirect_from: "/downloads"
            <div class="docMetaContent">
              <h2>Scala</h2>
              <a href="http://doc.akka.io/docs/akka/current/scala/index-actors.html">Reference</a>
-             <a href="http://doc.akka.io/api/akka/current/akka/actor/index.html">API</a>
+             <a href="https://doc.akka.io/api/akka/current/index.html#akka.actor.package">API</a>
            </div>
            <div class="docMetaContent">
              <h2>Java</h2>
@@ -128,7 +128,7 @@ redirect_from: "/downloads"
           <div class="docMetaContent">
             <h2>Scala</h2>
             <a href="http://doc.akka.io/docs/akka/current/scala/stream/index.html">Reference</a>
-            <a href="http://doc.akka.io/api/akka/current/akka/stream/index.html">API</a>
+            <a href="https://doc.akka.io/api/akka/current/index.html#akka.stream.package">API</a>
           </div>
           <div class="docMetaContent">
             <h2>Java</h2>
@@ -242,7 +242,7 @@ redirect_from: "/downloads"
           <div class="docMetaContent">
             <h2>Scala</h2>
             <a href="http://doc.akka.io/docs/akka/current/scala/cluster-usage.html">Reference</a>
-            <a href="http://doc.akka.io/api/akka/current/akka/cluster/index.html">API</a>
+            <a href="https://doc.akka.io/api/akka/current/index.html#akka.cluster.package">API</a>
           </div>
           <div class="docMetaContent">
             <h2>Java</h2>
@@ -287,12 +287,12 @@ redirect_from: "/downloads"
         <div class="docMeta">
           <div class="docMetaContent">
             <h2>Scala</h2>
-            <a href="http://doc.akka.io/docs/akka/current/scala/cluster-sharding.html">Reference</a>
-            <a href="http://doc.akka.io/api/akka/current/akka/cluster/sharding/index.html">API</a>
+            <a href="https://doc.akka.io/docs/akka/current/scala/cluster-sharding.html">Reference</a>
+            <a href="https://doc.akka.io/api/akka/current/index.html#akka.cluster.sharding.package">API</a>
           </div>
           <div class="docMetaContent">
             <h2>Java</h2>
-            <a href="http://doc.akka.io/docs/akka/current/java/cluster-sharding.html">Reference</a>
+            <a href="https://doc.akka.io/docs/akka/current/java/cluster-sharding.html">Reference</a>
             <a href="http://doc.akka.io/japi/akka/current/index.html?akka/cluster/sharding/package-summary.html">API</a>
           </div>
         </div>
@@ -334,7 +334,7 @@ redirect_from: "/downloads"
           <div class="docMetaContent">
             <h2>Scala</h2>
               <a href="http://doc.akka.io/docs/akka/current/scala/distributed-data.html">Reference</a>
-               <a href="http://doc.akka.io/api/akka/current/akka/cluster/ddata/index.html">API</a>
+               <a href="https://doc.akka.io/api/akka/current/index.html#akka.cluster.ddata.package">API</a>
              </div>
              <div class="docMetaContent">
                <h2>Java</h2>
@@ -385,7 +385,7 @@ redirect_from: "/downloads"
             <div class="docMetaContent">
               <h2>Scala</h2>
               <a href="http://doc.akka.io/docs/akka/current/scala/persistence.html">Reference</a>
-              <a href="http://doc.akka.io/api/akka/current/akka/persistence/index.html">API</a>
+              <a href="https://doc.akka.io/api/akka/current/index.html#akka.persistence.package">API</a>
             </div>
             <div class="docMetaContent">
               <h2>Java</h2>

--- a/docs/index.html
+++ b/docs/index.html
@@ -28,8 +28,8 @@ redirect_from: "/downloads"
                 <span class="searchVersion">Version <a href="https://github.com/akka/akka/issues?q=is%3Aissue+is%3Aclosed+milestone%3A{{page.current_akka_version }}">{{ page.current_akka_version }}</a></span>
             </div>
             <div class="headerButtons">
-                <a href="http://doc.akka.io/docs/akka/current/scala/index.html" class="bright">Scala contents</a>
-                <a href="http://doc.akka.io/docs/akka/current/java/index.html" class="bright">Java contents</a>
+                <a href="https://doc.akka.io/docs/akka/current/scala/index.html" class="bright">Scala contents</a>
+                <a href="https://doc.akka.io/docs/akka/current/java/index.html" class="bright">Java contents</a>
             </div>
         </div>
     </div>
@@ -42,10 +42,10 @@ redirect_from: "/downloads"
       <p>New to Akka, want to get up and running and learn the basics as fast as possible? Check out the get started section of the documentation!</p>
     </div>
     <div class="threecol">
-      <a class="btn getStartedBtn scala" href="http://doc.akka.io/docs/akka/current/scala/guide/introduction.html">Get started Scala</a>
+      <a class="btn getStartedBtn scala" href="https://doc.akka.io/docs/akka/current/scala/guide/introduction.html">Get started Scala</a>
     </div>
     <div class="threecol">
-      <a class="btn getStartedBtn java" href="http://doc.akka.io/docs/akka/current/java/guide/introduction.html">Get started Java</a>
+      <a class="btn getStartedBtn java" href="https://doc.akka.io/docs/akka/current/java/guide/introduction.html">Get started Java</a>
     </div>
   </div>
 </section>
@@ -70,13 +70,13 @@ redirect_from: "/downloads"
          <div class="docMeta">
            <div class="docMetaContent">
              <h2>Scala</h2>
-             <a href="http://doc.akka.io/docs/akka/current/scala/index-actors.html">Reference</a>
+             <a href="https://doc.akka.io/docs/akka/current/scala/index-actors.html">Reference</a>
              <a href="https://doc.akka.io/api/akka/current/index.html#akka.actor.package">API</a>
            </div>
            <div class="docMetaContent">
              <h2>Java</h2>
-             <a href="http://doc.akka.io/docs/akka/current/java/index-actors.html">Reference</a>
-             <a href="http://doc.akka.io/japi/akka/current/index.html?akka/actor/package-summary.html">API</a>
+             <a href="https://doc.akka.io/docs/akka/current/java/index-actors.html">Reference</a>
+             <a href="https://doc.akka.io/japi/akka/current/index.html?akka/actor/package-summary.html">API</a>
            </div>
          </div>
          <div class="docTabPanel">
@@ -127,13 +127,13 @@ redirect_from: "/downloads"
         <div class="docMeta">
           <div class="docMetaContent">
             <h2>Scala</h2>
-            <a href="http://doc.akka.io/docs/akka/current/scala/stream/index.html">Reference</a>
+            <a href="https://doc.akka.io/docs/akka/current/scala/stream/index.html">Reference</a>
             <a href="https://doc.akka.io/api/akka/current/index.html#akka.stream.package">API</a>
           </div>
           <div class="docMetaContent">
             <h2>Java</h2>
-            <a href="http://doc.akka.io/docs/akka/current/java/stream/index.html">Reference</a>
-            <a href="http://doc.akka.io/japi/akka/current/index.html?akka/stream/package-summary.html">API</a>
+            <a href="https://doc.akka.io/docs/akka/current/java/stream/index.html">Reference</a>
+            <a href="https://doc.akka.io/japi/akka/current/index.html?akka/stream/package-summary.html">API</a>
           </div>
         </div>
         <div class="docTabPanel">
@@ -182,13 +182,13 @@ redirect_from: "/downloads"
         <div class="docMeta">
           <div class="docMetaContent">
             <h2>Scala</h2>
-            <a href="http://doc.akka.io/docs/akka-http/current/scala/http/index.html">Reference</a>
-            <a href="http://doc.akka.io/api/akka-http/current/akka/http/scaladsl/index.html">API</a>
+            <a href="https://doc.akka.io/docs/akka-http/current/scala/http/index.html">Reference</a>
+            <a href="https://doc.akka.io/api/akka-http/current/akka/http/scaladsl/index.html">API</a>
           </div>
           <div class="docMetaContent">
             <h2>Java</h2>
-            <a href="http://doc.akka.io/docs/akka-http/current/java/http/index.html">Reference</a>
-            <a href="http://doc.akka.io/japi/akka-http/current/">API</a>
+            <a href="https://doc.akka.io/docs/akka-http/current/java/http/index.html">Reference</a>
+            <a href="https://doc.akka.io/japi/akka-http/current/">API</a>
           </div>
         </div>
         <div class="docTabPanel">
@@ -241,13 +241,13 @@ redirect_from: "/downloads"
         <div class="docMeta">
           <div class="docMetaContent">
             <h2>Scala</h2>
-            <a href="http://doc.akka.io/docs/akka/current/scala/cluster-usage.html">Reference</a>
+            <a href="https://doc.akka.io/docs/akka/current/scala/cluster-usage.html">Reference</a>
             <a href="https://doc.akka.io/api/akka/current/index.html#akka.cluster.package">API</a>
           </div>
           <div class="docMetaContent">
             <h2>Java</h2>
-            <a href="http://doc.akka.io/docs/akka/current/java/cluster-usage.html">Reference</a>
-            <a href="http://doc.akka.io/japi/akka/current/index.html?akka/cluster/package-summary.html">API</a>
+            <a href="https://doc.akka.io/docs/akka/current/java/cluster-usage.html">Reference</a>
+            <a href="https://doc.akka.io/japi/akka/current/index.html?akka/cluster/package-summary.html">API</a>
           </div>
         </div>
         <div class="docTabPanel">
@@ -293,7 +293,7 @@ redirect_from: "/downloads"
           <div class="docMetaContent">
             <h2>Java</h2>
             <a href="https://doc.akka.io/docs/akka/current/java/cluster-sharding.html">Reference</a>
-            <a href="http://doc.akka.io/japi/akka/current/index.html?akka/cluster/sharding/package-summary.html">API</a>
+            <a href="https://doc.akka.io/japi/akka/current/index.html?akka/cluster/sharding/package-summary.html">API</a>
           </div>
         </div>
         <div class="docTabPanel">
@@ -333,13 +333,13 @@ redirect_from: "/downloads"
         <div class="docMeta">
           <div class="docMetaContent">
             <h2>Scala</h2>
-              <a href="http://doc.akka.io/docs/akka/current/scala/distributed-data.html">Reference</a>
+              <a href="https://doc.akka.io/docs/akka/current/scala/distributed-data.html">Reference</a>
                <a href="https://doc.akka.io/api/akka/current/index.html#akka.cluster.ddata.package">API</a>
              </div>
              <div class="docMetaContent">
                <h2>Java</h2>
-               <a href="http://doc.akka.io/docs/akka/current/java/distributed-data.html">Reference</a>
-               <a href="http://doc.akka.io/japi/akka/current/index.html?akka/cluster/ddata/package-summary.html">API</a>
+               <a href="https://doc.akka.io/docs/akka/current/java/distributed-data.html">Reference</a>
+               <a href="https://doc.akka.io/japi/akka/current/index.html?akka/cluster/ddata/package-summary.html">API</a>
              </div>
            </div>
            <div class="docTabPanel">
@@ -384,13 +384,13 @@ redirect_from: "/downloads"
           <div class="docMeta">
             <div class="docMetaContent">
               <h2>Scala</h2>
-              <a href="http://doc.akka.io/docs/akka/current/scala/persistence.html">Reference</a>
+              <a href="https://doc.akka.io/docs/akka/current/scala/persistence.html">Reference</a>
               <a href="https://doc.akka.io/api/akka/current/index.html#akka.persistence.package">API</a>
             </div>
             <div class="docMetaContent">
               <h2>Java</h2>
-              <a href="http://doc.akka.io/docs/akka/current/java/persistence.html">Reference</a>
-              <a href="http://doc.akka.io/japi/akka/current/index.html?akka/persistence/package-summary.html">API</a>
+              <a href="https://doc.akka.io/docs/akka/current/java/persistence.html">Reference</a>
+              <a href="https://doc.akka.io/japi/akka/current/index.html?akka/persistence/package-summary.html">API</a>
             </div>
           </div>
           <div class="docTabPanel">
@@ -431,7 +431,7 @@ redirect_from: "/downloads"
                <h2>Scala and Java</h2>
              </div>
              <div class="docMetaContent">
-               <a href="http://developer.lightbend.com/docs/alpakka/current/">Reference</a>
+               <a href="https://developer.lightbend.com/docs/alpakka/current/">Reference</a>
                <a href="https://github.com/akka/alpakka/">Repository</a>
              </div>
           </div>


### PR DESCRIPTION
Page layout changed from having an index page per package, to having to list that index from the top-level index.html