### PR TITLE
Change scala api links to 2.12-scaladoc style again

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -71,7 +71,7 @@ redirect_from: "/downloads"
            <div class="docMetaContent">
              <h2>Scala</h2>
              <a href="https://doc.akka.io/docs/akka/current/scala/index-actors.html">Reference</a>
-             <a href="https://doc.akka.io/api/akka/current/index.html#akka.actor.package">API</a>
+             <a href="https://doc.akka.io/api/akka/current/akka/actor/index.html">API</a>
            </div>
            <div class="docMetaContent">
              <h2>Java</h2>
@@ -128,7 +128,7 @@ redirect_from: "/downloads"
           <div class="docMetaContent">
             <h2>Scala</h2>
             <a href="https://doc.akka.io/docs/akka/current/scala/stream/index.html">Reference</a>
-            <a href="https://doc.akka.io/api/akka/current/index.html#akka.stream.package">API</a>
+            <a href="https://doc.akka.io/api/akka/current/akka/stream/index.html">API</a>
           </div>
           <div class="docMetaContent">
             <h2>Java</h2>
@@ -242,7 +242,7 @@ redirect_from: "/downloads"
           <div class="docMetaContent">
             <h2>Scala</h2>
             <a href="https://doc.akka.io/docs/akka/current/scala/cluster-usage.html">Reference</a>
-            <a href="https://doc.akka.io/api/akka/current/index.html#akka.cluster.package">API</a>
+            <a href="https://doc.akka.io/api/akka/current/akka/cluster/index.html">API</a>
           </div>
           <div class="docMetaContent">
             <h2>Java</h2>
@@ -288,7 +288,7 @@ redirect_from: "/downloads"
           <div class="docMetaContent">
             <h2>Scala</h2>
             <a href="https://doc.akka.io/docs/akka/current/scala/cluster-sharding.html">Reference</a>
-            <a href="https://doc.akka.io/api/akka/current/index.html#akka.cluster.sharding.package">API</a>
+            <a href="https://doc.akka.io/api/akka/current/akka/cluster/sharding/index.html">API</a>
           </div>
           <div class="docMetaContent">
             <h2>Java</h2>
@@ -334,7 +334,7 @@ redirect_from: "/downloads"
           <div class="docMetaContent">
             <h2>Scala</h2>
               <a href="https://doc.akka.io/docs/akka/current/scala/distributed-data.html">Reference</a>
-               <a href="https://doc.akka.io/api/akka/current/index.html#akka.cluster.ddata.package">API</a>
+               <a href="https://doc.akka.io/api/akka/current/akka/cluster/ddata/index.html">API</a>
              </div>
              <div class="docMetaContent">
                <h2>Java</h2>
@@ -385,7 +385,7 @@ redirect_from: "/downloads"
             <div class="docMetaContent">
               <h2>Scala</h2>
               <a href="https://doc.akka.io/docs/akka/current/scala/persistence.html">Reference</a>
-              <a href="https://doc.akka.io/api/akka/current/index.html#akka.persistence.package">API</a>
+              <a href="https://doc.akka.io/api/akka/current/akka/persistence/index.html">API</a>
             </div>
             <div class="docMetaContent">
               <h2>Java</h2>


### PR DESCRIPTION
Partially reverts #526 since we updated the scaladocs