### PR TITLE
Add missing change in Akka Typed API

### DIFF
--- a/blog/_posts/2018-10-07-akka-2.5.18-released.md
+++ b/blog/_posts/2018-10-07-akka-2.5.18-released.md
@@ -34,6 +34,7 @@ A total of 66 issues were closed since 2.5.17. The complete list can be found on
 ### Actor
 
 * Rename MutableBehavior to AbstractBehavior [#25750](https://github.com/akka/akka/issues/25750), see documentation of [Object-oriented style](https://doc.akka.io/docs/akka/current/typed/actors.html#object-oriented-style)
+* Rename ActorContext#schedule to scheduleOnce [#25869](https://github.com/akka/akka/pull/25869)
 
 ### Cluster Sharding
 


### PR DESCRIPTION
`Rename ActorContext#schedule with scheduleOnce` change has been forgotten in the release notes