### PR TITLE
Drop the dependency info boxes

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -28,8 +28,8 @@ redirect_from: "/downloads"
                 <span class="searchVersion">Version <a href="https://github.com/akka/akka/issues?q=is%3Aissue+is%3Aclosed+milestone%3A{{page.current_akka_version }}">{{ page.current_akka_version }}</a></span>
             </div>
             <div class="headerButtons">
-                <a href="https://doc.akka.io/docs/akka/current/scala/index.html" class="bright">Scala contents</a>
-                <a href="https://doc.akka.io/docs/akka/current/java/index.html" class="bright">Java contents</a>
+                <a href="https://doc.akka.io/docs/akka/current/index.html?language=scala" class="bright">Scala contents</a>
+                <a href="https://doc.akka.io/docs/akka/current/index.html?language=java" class="bright">Java contents</a>
             </div>
         </div>
     </div>
@@ -42,10 +42,10 @@ redirect_from: "/downloads"
       <p>New to Akka, want to get up and running and learn the basics as fast as possible? Check out the get started section of the documentation!</p>
     </div>
     <div class="threecol">
-      <a class="btn getStartedBtn scala" href="https://doc.akka.io/docs/akka/current/scala/guide/introduction.html">Get started Scala</a>
+      <a class="btn getStartedBtn scala" href="https://doc.akka.io/docs/akka/current/guide/introduction.html?language=scala">Get started Scala</a>
     </div>
     <div class="threecol">
-      <a class="btn getStartedBtn java" href="https://doc.akka.io/docs/akka/current/java/guide/introduction.html">Get started Java</a>
+      <a class="btn getStartedBtn java" href="https://doc.akka.io/docs/akka/current/guide/introduction.html?language=java">Get started Java</a>
     </div>
   </div>
 </section>
@@ -58,7 +58,7 @@ redirect_from: "/downloads"
   </div>
   <div class="row">
     <div class="docModuleGrid">
-       <div class="box">
+       <div class="box single-column">
          <h1>Akka Actors</h1>
          <span class="underLine"></span>
          <p>
@@ -68,19 +68,17 @@ redirect_from: "/downloads"
            Current version: <code>{{page.current_akka_version}}</code>
          </p>
          <div class="docMeta">
-           <div class="docMetaContent">
-             <h2>Scala</h2>
-             <a href="https://doc.akka.io/docs/akka/current/scala/index-actors.html">Reference</a>
-             <a href="https://doc.akka.io/api/akka/current/akka/actor/index.html">API</a>
+           <div>
+               <h2>Scala and Java</h2>
            </div>
            <div class="docMetaContent">
-             <h2>Java</h2>
-             <a href="https://doc.akka.io/docs/akka/current/java/index-actors.html">Reference</a>
-             <a href="https://doc.akka.io/japi/akka/current/index.html?akka/actor/package-summary.html">API</a>
+             <a href="https://doc.akka.io/docs/akka/current/index-actors.html">Reference</a>
+             <a href="https://doc.akka.io/api/akka/current/akka/actor/index.html">Scala API</a>
+             <a href="https://doc.akka.io/japi/akka/current/index.html?akka/actor/package-summary.html">Java API</a>
            </div>
          </div>
       </div>
-      <div class="box">
+      <div class="box single-column">
         <h1>Akka Streams</h1>
         <span class="underLine"></span>
         <p>
@@ -90,19 +88,17 @@ redirect_from: "/downloads"
           Current version: <code>{{page.current_akka_version}}</code>
         </p>
         <div class="docMeta">
+            <div>
+                <h2>Scala and Java</h2>
+            </div>
           <div class="docMetaContent">
-            <h2>Scala</h2>
-            <a href="https://doc.akka.io/docs/akka/current/scala/stream/index.html">Reference</a>
-            <a href="https://doc.akka.io/api/akka/current/akka/stream/index.html">API</a>
-          </div>
-          <div class="docMetaContent">
-            <h2>Java</h2>
-            <a href="https://doc.akka.io/docs/akka/current/java/stream/index.html">Reference</a>
-            <a href="https://doc.akka.io/japi/akka/current/index.html?akka/stream/package-summary.html">API</a>
+            <a href="https://doc.akka.io/docs/akka/current/stream/index.html">Reference</a>
+            <a href="https://doc.akka.io/api/akka/current/akka/stream/index.html">Scala API</a>
+            <a href="https://doc.akka.io/japi/akka/current/index.html?akka/stream/package-summary.html">Java API</a>
           </div>
         </div>
       </div>
-      <div class="box">
+      <div class="box single-column">
         <h1>Akka HTTP</h1>
         <span class="underLine"></span>
         <p>
@@ -112,15 +108,13 @@ redirect_from: "/downloads"
           Current version: <code>{{page.current_akka_http_version}}</code>
         </p>
         <div class="docMeta">
+            <div>
+                <h2>Scala and Java</h2>
+            </div>
           <div class="docMetaContent">
-            <h2>Scala</h2>
-            <a href="https://doc.akka.io/docs/akka-http/current/scala/http/index.html">Reference</a>
-            <a href="https://doc.akka.io/api/akka-http/current/akka/http/scaladsl/index.html">API</a>
-          </div>
-          <div class="docMetaContent">
-            <h2>Java</h2>
-            <a href="https://doc.akka.io/docs/akka-http/current/java/http/index.html">Reference</a>
-            <a href="https://doc.akka.io/japi/akka-http/current/">API</a>
+            <a href="https://doc.akka.io/docs/akka-http/current/introduction.html">Reference</a>
+            <a href="https://doc.akka.io/api/akka-http/current/akka/http/scaladsl/index.html">Scala API</a>
+            <a href="https://doc.akka.io/japi/akka-http/current/">Java API</a>
           </div>
         </div>
       </div>
@@ -128,7 +122,7 @@ redirect_from: "/downloads"
   </div>
   <div class="row">
     <div class="docModuleGrid">
-      <div class="box">
+      <div class="box single-column">
         <h1>Akka Cluster</h1>
         <span class="underLine"></span>
         <p>
@@ -138,19 +132,17 @@ redirect_from: "/downloads"
           Current version: <code>{{page.current_akka_version}}</code>
         </p>
         <div class="docMeta">
+            <div>
+                <h2>Scala and Java</h2>
+            </div>
           <div class="docMetaContent">
-            <h2>Scala</h2>
-            <a href="https://doc.akka.io/docs/akka/current/scala/cluster-usage.html">Reference</a>
-            <a href="https://doc.akka.io/api/akka/current/akka/cluster/index.html">API</a>
-          </div>
-          <div class="docMetaContent">
-            <h2>Java</h2>
-            <a href="https://doc.akka.io/docs/akka/current/java/cluster-usage.html">Reference</a>
-            <a href="https://doc.akka.io/japi/akka/current/index.html?akka/cluster/package-summary.html">API</a>
+            <a href="https://doc.akka.io/docs/akka/current/cluster-usage.html">Reference</a>
+            <a href="https://doc.akka.io/api/akka/current/akka/cluster/index.html">Scala API</a>
+            <a href="https://doc.akka.io/japi/akka/current/index.html?akka/cluster/package-summary.html">Java API</a>
           </div>
         </div>
       </div>
-      <div class="box">
+      <div class="box single-column">
         <h1>Cluster Sharding</h1>
         <span class="underLine"></span>
         <p>
@@ -160,19 +152,17 @@ redirect_from: "/downloads"
             Current version: <code>{{page.current_akka_version}}</code>
         </p>
         <div class="docMeta">
+            <div>
+                <h2>Scala and Java</h2>
+            </div>
           <div class="docMetaContent">
-            <h2>Scala</h2>
-            <a href="https://doc.akka.io/docs/akka/current/scala/cluster-sharding.html">Reference</a>
-            <a href="https://doc.akka.io/api/akka/current/akka/cluster/sharding/index.html">API</a>
-          </div>
-          <div class="docMetaContent">
-            <h2>Java</h2>
-            <a href="https://doc.akka.io/docs/akka/current/java/cluster-sharding.html">Reference</a>
-            <a href="https://doc.akka.io/japi/akka/current/index.html?akka/cluster/sharding/package-summary.html">API</a>
+            <a href="https://doc.akka.io/docs/akka/current/cluster-sharding.html">Reference</a>
+            <a href="https://doc.akka.io/api/akka/current/akka/cluster/sharding/index.html">Scala API</a>
+            <a href="https://doc.akka.io/japi/akka/current/index.html?akka/cluster/sharding/package-summary.html">Java API</a>
           </div>
         </div>
       </div>
-      <div class="box">
+      <div class="box single-column">
         <h1>Distributed Data</h1>
         <span class="underLine"></span>
         <p>
@@ -182,15 +172,13 @@ redirect_from: "/downloads"
             Current version: <code>{{page.current_akka_version}}</code>
         </p>
         <div class="docMeta">
+            <div>
+                <h2>Scala and Java</h2>
+            </div>
           <div class="docMetaContent">
-            <h2>Scala</h2>
-              <a href="https://doc.akka.io/docs/akka/current/scala/distributed-data.html">Reference</a>
-               <a href="https://doc.akka.io/api/akka/current/akka/cluster/ddata/index.html">API</a>
-             </div>
-             <div class="docMetaContent">
-               <h2>Java</h2>
-               <a href="https://doc.akka.io/docs/akka/current/java/distributed-data.html">Reference</a>
-               <a href="https://doc.akka.io/japi/akka/current/index.html?akka/cluster/ddata/package-summary.html">API</a>
+              <a href="https://doc.akka.io/docs/akka/current/distributed-data.html">Reference</a>
+               <a href="https://doc.akka.io/api/akka/current/akka/cluster/ddata/index.html">Scala API</a>
+               <a href="https://doc.akka.io/japi/akka/current/index.html?akka/cluster/ddata/package-summary.html">Java API</a>
              </div>
            </div>
         </div>
@@ -198,7 +186,7 @@ redirect_from: "/downloads"
     </div>
     <div class="row">
       <div class="docModuleGrid">
-        <div class="box">
+        <div class="box single-column">
           <h1>Akka Persistence</h1>
           <span class="underLine"></span>
           <p>
@@ -208,15 +196,13 @@ redirect_from: "/downloads"
               Current version: <code>{{page.current_akka_version}}</code>
           </p>
           <div class="docMeta">
-            <div class="docMetaContent">
-              <h2>Scala</h2>
-              <a href="https://doc.akka.io/docs/akka/current/scala/persistence.html">Reference</a>
-              <a href="https://doc.akka.io/api/akka/current/akka/persistence/index.html">API</a>
-            </div>
-            <div class="docMetaContent">
-              <h2>Java</h2>
-              <a href="https://doc.akka.io/docs/akka/current/java/persistence.html">Reference</a>
-              <a href="https://doc.akka.io/japi/akka/current/index.html?akka/persistence/package-summary.html">API</a>
+              <div>
+                <h2>Scala and Java</h2>
+              </div>
+              <div class="docMetaContent">
+              <a href="https://doc.akka.io/docs/akka/current/persistence.html">Reference</a>
+              <a href="https://doc.akka.io/api/akka/current/akka/persistence/index.html">Scala API</a>
+              <a href="https://doc.akka.io/japi/akka/current/index.html?akka/persistence/package-summary.html">Java API</a>
             </div>
           </div>
         </div>
@@ -247,7 +233,7 @@ redirect_from: "/downloads"
                <h2>Scala and Java</h2>
              </div>
              <div class="docMetaContent">
-               <a href="https://doc.akka.io/docs/alpakka-kafka/">Reference</a>
+               <a href="https://doc.akka.io/docs/alpakka-kafka/current/home.html">Reference</a>
                <a href="https://github.com/akka/alpakka-kafka/">Repository</a>
              </div>
           </div>
@@ -273,11 +259,12 @@ redirect_from: "/downloads"
               </div>
           </div>
         <div class="box single-column">
-          <h1>Commercial Addons</h1>
+          <h1>Akka Enhancements</h1>
           <span class="underLine"></span>
           <p>
-              <!--<code>TODO commercial addons version here</code>-->
-              Commercial Addons, including split brain resolver, Multi-DC Persistence and much more.
+              <!--<code>TODO version here</code>-->
+              Akka Enhancements is a suite of useful components that complement Akka, such as "Split Brain Resolver",
+              "Config Checker", "Akka Multi-DC persistence", and others.
           </p>
           <div class="docMeta">
              <div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -79,41 +79,6 @@ redirect_from: "/downloads"
              <a href="https://doc.akka.io/japi/akka/current/index.html?akka/actor/package-summary.html">API</a>
            </div>
          </div>
-         <div class="docTabPanel">
-           <ul class="tabPanelList">
-             <li rel="1-panel-sbt" class="active">sbt</li>
-             <li rel="1-panel-gradle">Gradle</li>
-             <li rel="1-panel-maven">Maven</li>
-           </ul>
-           <div id="1-panel-sbt" class="tabPanel active">
-
-<pre><div class="copyBtn hidden" title="copy to clipboard"></div>libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-actor" % "{{page.current_akka_version}}",
-  "com.typesafe.akka" %% "akka-testkit" % "{{page.current_akka_version}}" % Test
-)
-</pre>
-           </div>
-           <div id="1-panel-gradle" class="tabPanel">
-
-<pre><div class="copyBtn hidden" title="copy to clipboard"></div>dependencies {
-  compile group: 'com.typesafe.akka', name: 'akka-actor_{{page.current_java_scala_version}}', version: '{{page.current_akka_version}}'
-  testCompile group: 'com.typesafe.akka', name: 'akka-testkit_{{page.current_java_scala_version}}', version: '{{page.current_akka_version}}'
-}</pre>
-           </div>
-           <div id="1-panel-maven" class="tabPanel">
-<pre><div class="copyBtn hidden" title="copy to clipboard"></div>&lt;dependency&gt;
-  &lt;groupId&gt;com.typesafe.akka&lt;/groupId&gt;
-  &lt;artifactId&gt;akka-actor_{{page.current_java_scala_version}}&lt;/artifactId&gt;
-  &lt;version&gt;{{page.current_akka_version}}&lt;/version&gt;
-&lt;/dependency&gt;
-&lt;dependency&gt;
-  &lt;groupId&gt;com.typesafe.akka&lt;/groupId&gt;
-  &lt;artifactId&gt;akka-testkit_{{page.current_java_scala_version}}&lt;/artifactId&gt;
-  &lt;version&gt;{{page.current_akka_version}}&lt;/version&gt;
-  &lt;scope&gt;test&lt;/scope&gt;
-&lt;/dependency&gt;</pre>
-           </div>
-         </div>
       </div>
       <div class="box">
         <h1>Akka Streams</h1>
@@ -136,39 +101,6 @@ redirect_from: "/downloads"
             <a href="https://doc.akka.io/japi/akka/current/index.html?akka/stream/package-summary.html">API</a>
           </div>
         </div>
-        <div class="docTabPanel">
-          <ul class="tabPanelList">
-            <li rel="2-panel-sbt" class="active">sbt</li>
-            <li rel="2-panel-gradle">Gradle</li>
-            <li rel="2-panel-maven">Maven</li>
-          </ul>
-          <div id="2-panel-sbt" class="tabPanel active">
-<pre><div class="copyBtn hidden" title="copy to clipboard"></div>libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-stream" % "{{page.current_akka_version}}",
-  "com.typesafe.akka" %% "akka-stream-testkit" % "{{page.current_akka_version}}" % Test
-)
-</pre>
-          </div>
-          <div id="2-panel-gradle" class="tabPanel">
-<pre><div class="copyBtn hidden" title="copy to clipboard"></div>dependencies {
-  compile group: 'com.typesafe.akka', name: 'akka-stream_{{page.current_java_scala_version}}', version:'{{page.current_akka_version}}'
-  testCompile group: 'com.typesafe.akka', name: 'akka-stream-testkit_{{page.current_java_scala_version}}', version:'{{page.current_akka_version}}'
-}</pre>
-          </div>
-          <div id="2-panel-maven" class="tabPanel">
-<pre><div class="copyBtn hidden" title="copy to clipboard"></div>&lt;dependency&gt;
-  &lt;groupId&gt;com.typesafe.akka&lt;/groupId&gt;
-  &lt;artifactId&gt;akka-stream_{{page.current_java_scala_version}}&lt;/artifactId&gt;
-  &lt;version&gt;{{page.current_akka_version}}&lt;/version&gt;
-&lt;/dependency&gt;
-&lt;dependency&gt;
-  &lt;groupId&gt;com.typesafe.akka&lt;/groupId&gt;
-  &lt;artifactId&gt;akka-stream-testkit_{{page.current_java_scala_version}}&lt;/artifactId&gt;
-  &lt;version&gt;{{page.current_akka_version}}&lt;/version&gt;
-  &lt;scope&gt;test&lt;/scope&gt;
-&lt;/dependency&gt;</pre>
-          </div>
-        </div>
       </div>
       <div class="box">
         <h1>Akka HTTP</h1>
@@ -189,39 +121,6 @@ redirect_from: "/downloads"
             <h2>Java</h2>
             <a href="https://doc.akka.io/docs/akka-http/current/java/http/index.html">Reference</a>
             <a href="https://doc.akka.io/japi/akka-http/current/">API</a>
-          </div>
-        </div>
-        <div class="docTabPanel">
-          <ul class="tabPanelList">
-            <li rel="3-panel-sbt" class="active">sbt</li>
-            <li rel="3-panel-gradle">Gradle</li>
-            <li rel="3-panel-maven">Maven</li>
-          </ul>
-          <div id="3-panel-sbt" class="tabPanel active">
-<pre><div class="copyBtn hidden" title="copy to clipboard"></div>libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-http" % "{{page.current_akka_http_version}}",
-  "com.typesafe.akka" %% "akka-http-testkit" % "{{page.current_akka_http_version}}" % Test
-)
-</pre>
-          </div>
-          <div id="3-panel-gradle" class="tabPanel">
-<pre><div class="copyBtn hidden" title="copy to clipboard"></div>dependencies {
-  compile group: 'com.typesafe.akka', name: 'akka-http_{{page.current_java_scala_version}}', version:'{{page.current_akka_http_version}}'
-  testCompile group: 'com.typesafe.akka', name: 'akka-http-testkit_{{page.current_java_scala_version}}', version:'{{page.current_akka_http_version}}'
-}</pre>
-          </div>
-          <div id="3-panel-maven" class="tabPanel">
-<pre><div class="copyBtn hidden" title="copy to clipboard"></div>&lt;dependency&gt;
-  &lt;groupId&gt;com.typesafe.akka&lt;/groupId&gt;
-  &lt;artifactId&gt;akka-http_{{page.current_java_scala_version}}&lt;/artifactId&gt;
-  &lt;version&gt;{{page.current_akka_http_version}}&lt;/version&gt;
-&lt;/dependency&gt;
-&lt;dependency&gt;
-  &lt;groupId&gt;com.typesafe.akka&lt;/groupId&gt;
-  &lt;artifactId&gt;akka-http-testkit_{{page.current_java_scala_version}}&lt;/artifactId&gt;
-  &lt;version&gt;{{page.current_akka_http_version}}&lt;/version&gt;
-  &lt;scope&gt;test&lt;/scope&gt;
-&lt;/dependency&gt;</pre>
           </div>
         </div>
       </div>
@@ -250,30 +149,6 @@ redirect_from: "/downloads"
             <a href="https://doc.akka.io/japi/akka/current/index.html?akka/cluster/package-summary.html">API</a>
           </div>
         </div>
-        <div class="docTabPanel">
-          <ul class="tabPanelList">
-            <li rel="4-panel-sbt" class="active">sbt</li>
-            <li rel="4-panel-gradle">Gradle</li>
-            <li rel="4-panel-maven">Maven</li>
-          </ul>
-          <div id="4-panel-sbt" class="tabPanel active">
-<pre><div class="copyBtn hidden" title="copy to clipboard"></div>libraryDependencies +=
-  "com.typesafe.akka" %% "akka-cluster" % "{{page.current_akka_version}}"
-</pre>
-          </div>
-          <div id="4-panel-gradle" class="tabPanel">
-<pre><div class="copyBtn hidden" title="copy to clipboard"></div>dependencies {
-  compile group: 'com.typesafe.akka', name: 'akka-cluster_{{page.current_java_scala_version}}', version: '{{page.current_akka_version}}'
-}</pre>
-          </div>
-          <div id="4-panel-maven" class="tabPanel">
-<pre><div class="copyBtn hidden" title="copy to clipboard"></div>&lt;dependency&gt;
-  &lt;groupId&gt;com.typesafe.akka&lt;/groupId&gt;
-  &lt;artifactId&gt;akka-cluster_{{page.current_java_scala_version}}&lt;/artifactId&gt;
-  &lt;version&gt;{{page.current_akka_version}}&lt;/version&gt;
-&lt;/dependency&gt;</pre>
-          </div>
-        </div>
       </div>
       <div class="box">
         <h1>Cluster Sharding</h1>
@@ -296,30 +171,6 @@ redirect_from: "/downloads"
             <a href="https://doc.akka.io/japi/akka/current/index.html?akka/cluster/sharding/package-summary.html">API</a>
           </div>
         </div>
-        <div class="docTabPanel">
-          <ul class="tabPanelList">
-            <li rel="5-panel-sbt" class="active">sbt</li>
-            <li rel="5-panel-gradle">Gradle</li>
-            <li rel="5-panel-maven">Maven</li>
-          </ul>
-          <div id="5-panel-sbt" class="tabPanel active">
-<pre><div class="copyBtn hidden" title="copy to clipboard"></div>libraryDependencies +=
-  "com.typesafe.akka" %% "akka-cluster-sharding" %  "{{page.current_akka_version}}"
-</pre>
-          </div>
-          <div id="5-panel-gradle" class="tabPanel">
-<pre><div class="copyBtn hidden" title="copy to clipboard"></div>dependencies {
-  compile group: 'com.typesafe.akka', name: 'akka-cluster-sharding_{{page.current_java_scala_version}}', version: '{{page.current_akka_version}}'
-}</pre>
-          </div>
-          <div id="5-panel-maven" class="tabPanel">
-<pre><div class="copyBtn hidden" title="copy to clipboard"></div>&lt;dependency&gt;
-  &lt;groupId&gt;com.typesafe.akka&lt;/groupId&gt;
-  &lt;artifactId&gt;akka-cluster-sharding_{{page.current_java_scala_version}}&lt;/artifactId&gt;
-  &lt;version&gt;{{page.current_akka_version}}&lt;/version&gt;
-&lt;/dependency&gt;</pre>
-          </div>
-        </div>
       </div>
       <div class="box">
         <h1>Distributed Data</h1>
@@ -340,31 +191,6 @@ redirect_from: "/downloads"
                <h2>Java</h2>
                <a href="https://doc.akka.io/docs/akka/current/java/distributed-data.html">Reference</a>
                <a href="https://doc.akka.io/japi/akka/current/index.html?akka/cluster/ddata/package-summary.html">API</a>
-             </div>
-           </div>
-           <div class="docTabPanel">
-             <ul class="tabPanelList">
-               <li rel="7-panel-sbt" class="active">sbt</li>
-               <li rel="7-panel-gradle">Gradle</li>
-               <li rel="7-panel-maven">Maven</li>
-             </ul>
-             <div id="7-panel-sbt" class="tabPanel active">
-<pre><div class="copyBtn hidden" title="copy to clipboard"></div>libraryDependencies +=
-  "com.typesafe.akka" %% "akka-distributed-data" % "{{page.current_akka_version}}"
-</pre>
-             </div>
-             <div id="7-panel-gradle" class="tabPanel">
-<pre><div class="copyBtn hidden" title="copy to clipboard"></div>dependencies {
-  compile group: 'com.typesafe.akka', name: 'akka-distributed-data_{{page.current_java_scala_version}}', version: '{{page.current_akka_version}}'
-}
-</pre>
-             </div>
-             <div id="7-panel-maven" class="tabPanel">
-<pre><div class="copyBtn hidden" title="copy to clipboard"></div>&lt;dependency&gt;
-  &lt;groupId&gt;com.typesafe.akka&lt;/groupId&gt;
-  &lt;artifactId&gt;akka-distributed-data_{{page.current_java_scala_version}}&lt;/artifactId&gt;
-  &lt;version&gt;{{page.current_akka_version}}&lt;/version&gt;
-&lt;/dependency&gt;</pre>
              </div>
            </div>
         </div>
@@ -391,31 +217,6 @@ redirect_from: "/downloads"
               <h2>Java</h2>
               <a href="https://doc.akka.io/docs/akka/current/java/persistence.html">Reference</a>
               <a href="https://doc.akka.io/japi/akka/current/index.html?akka/persistence/package-summary.html">API</a>
-            </div>
-          </div>
-          <div class="docTabPanel">
-            <ul class="tabPanelList">
-              <li rel="8-panel-sbt" class="active">sbt</li>
-              <li rel="8-panel-gradle">Gradle</li>
-              <li rel="8-panel-maven">Maven</li>
-            </ul>
-            <div id="8-panel-sbt" class="tabPanel active">
-<pre><div class="copyBtn hidden" title="copy to clipboard"></div>libraryDependencies +=
-  "com.typesafe.akka" %% "akka-persistence" % "{{page.current_akka_version}}"
-</pre>
-            </div>
-            <div id="8-panel-gradle" class="tabPanel">
-<pre><div class="copyBtn hidden" title="copy to clipboard"></div>dependencies {
-  compile group: 'com.typesafe.akka', name: 'akka-persistence_{{page.current_java_scala_version}}', version: '{{page.current_akka_version}}'
-}
-</pre>
-            </div>
-            <div id="8-panel-maven" class="tabPanel">
-<pre><div class="copyBtn hidden" title="copy to clipboard"></div>&lt;dependency&gt;
-  &lt;groupId&gt;com.typesafe.akka&lt;/groupId&gt;
-  &lt;artifactId&gt;akka-persistence_{{page.current_java_scala_version}}&lt;/artifactId&gt;
-  &lt;version&gt;{{page.current_akka_version}}&lt;/version&gt;
-&lt;/dependency&gt;</pre>
             </div>
           </div>
         </div>


### PR DESCRIPTION
The dependency info for different build tools is nowadays well present in all Akka docs and should be dropped from the overview page

(I'm referring to this kind of box on https://akka.io/docs/)
![bild](https://user-images.githubusercontent.com/458526/53819231-d0e07e00-3f69-11e9-8759-1067bdf87e8f.png)
