### PR TITLE
Bump current_akka_http_version to 10.1.8

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,6 @@ defaults:
     # versions.json will be updated as long as the changes here are patch versions, for minor and major it needs to
     # be updated manually
     current_akka_version: 2.5.21
-    current_akka_http_version: 10.1.7
+    current_akka_http_version: 10.1.8
     previous_akka_version: 2.4.20
     current_java_scala_version: 2.12 # used for deps for Java


### PR DESCRIPTION
Hi, I didn't see a CONTRIBUTING.md file.
I just noticed that the `current_akka_http_version` on https://akka.io/docs/ is 10.1.7 so I figured I'd open this quick PR to update it. I'm also going to comment on https://github.com/akka/akka-http/issues/2466 to add this to the release train checklist. Let me know if I missed something. Thanks!