### PR TITLE
use 2.5 instead of current in link to migration guide

### DIFF
--- a/blog/_posts/2018-01-11-akka-2.5.9-released-2.4.x-end-of-life.md
+++ b/blog/_posts/2018-01-11-akka-2.5.9-released-2.4.x-end-of-life.md
@@ -31,7 +31,7 @@ in accordance to our [documented compatibility guidelines](https://doc.akka.io/d
 
 This especially means that guaranteed hotfixes for this branch will not be available after this point.
 We always recommend staying up to date with the latest release, which is currently Akka 2.5.9.
-When upgrading please make sure to utilize the [migration documentation](https://doc.akka.io/docs/akka/current/project/migration-guide-2.4.x-2.5.x.html) as necessary.
+When upgrading please make sure to utilize the [migration documentation](https://doc.akka.io/docs/akka/2.5/project/migration-guide-2.4.x-2.5.x.html) as necessary.
 
 ## Akka Typed
 


### PR DESCRIPTION
* because old migration guides are removed
