### PR TITLE
Change links from developer.lightbend.com to doc.akka.io

### DIFF
--- a/blog/_posts/2017-10-23-native-akka-streams-in-spring-web-and-boot-via-alpakka.md
+++ b/blog/_posts/2017-10-23-native-akka-streams-in-spring-web-and-boot-via-alpakka.md
@@ -10,7 +10,7 @@ tags: [alpakka,releases]
 
 In today's blog post we want to highlight a specific new integration that has landed in Alpakka. Specifically, it allows you to seamlessly integrate with your `akka.stream.[javadsl|scaladsl].Source` types in your Spring Web applications, and have them be understood by Spring natively.
 
-[Alpakka](https://developer.lightbend.com/docs/alpakka/current), is our way of solving the *Reactive Enterprise Integration* problem. We do so by providing a collection of *streaming* plug-and-play connectors to various technologies. Today we'd like to highlight one specific integration, since it's the result of the [Reactive Streams](http://reactive-streams.org) initiative, which we were part of from its inception. And also explains what its [successful inclusion in the Java 9](http://download.java.net/java/jdk9/docs/api/java/util/concurrent/Flow.html) means for the future of inter-operability of Reactive Streams based libraries.
+[Alpakka](https://doc.akka.io/docs/alpakka/current), is our way of solving the *Reactive Enterprise Integration* problem. We do so by providing a collection of *streaming* plug-and-play connectors to various technologies. Today we'd like to highlight one specific integration, since it's the result of the [Reactive Streams](http://reactive-streams.org) initiative, which we were part of from its inception. And also explains what its [successful inclusion in the Java 9](http://download.java.net/java/jdk9/docs/api/java/util/concurrent/Flow.html) means for the future of inter-operability of Reactive Streams based libraries.
 
 On a related note, Akka Streams is one of the first libraries to provide native support for Java 9's `java.util.concurrent.Flow.*` (as of writing, Spring does not provide this support yet, while RxJava provides bridges separately packaged), so if you're looking for a future-ready Reactive Streams implementation, simply use Akka Streams `2.5.6+` and you're ready to go.
 
@@ -18,7 +18,7 @@ Let's focus on today's highlight though, the new Spring Web compatibility module
 
 ### Using Akka Streams natively in Spring Web endpoints
 
-Thanks to [Alpakka](https://developer.lightbend.com/docs/alpakka/current)'s integration code (included since version `0.14`), you're now able to depend on the [akka-stream-alpakka-spring-web](https://developer.lightbend.com/docs/alpakka/current/spring-web.html) Alpakka module: 
+Thanks to [Alpakka](https://doc.akka.io/docs/alpakka/current)'s integration code (included since version `0.14`), you're now able to depend on the [akka-stream-alpakka-spring-web](https://doc.akka.io/docs/alpakka/current/spring-web.html) Alpakka module: 
 
 ```
 // build.gradle

--- a/blog/_posts/2018-05-02-alpakka-team.md
+++ b/blog/_posts/2018-05-02-alpakka-team.md
@@ -9,7 +9,7 @@ tags: [alpakka,streams]
 
 Dear hakkers,
 
-One and a half years ago the Akka Team [announced](https://akka.io/blog/2016/08/23/intro-alpakka) a place for the community to collect endpoints for systems integration with Akka Streams: [Alpakka](https://developer.lightbend.com/docs/alpakka/current/).
+One and a half years ago the Akka Team [announced](https://akka.io/blog/2016/08/23/intro-alpakka) a place for the community to collect endpoints for systems integration with Akka Streams: [Alpakka](https://doc.akka.io/docs/alpakka/current/).
 The community showed its strength and we've received a lot of great contributions to this effort to enable enterprise integration in a reactive way.
 
 During this time the Akka Team has enjoyed this great interest to contribute to Alpakka, but did not get to review Pull Requests as often as they would have liked. Core Akka and exploration of useful additions to it has been their main focus.

--- a/blog/_posts/2018-08-30-alpakka-towards-1.0.md
+++ b/blog/_posts/2018-08-30-alpakka-towards-1.0.md
@@ -9,7 +9,7 @@ tags: [alpakka,streams]
 
 Dear hakkers,
 
-Akka's satellite project to collect Reactive Enterprise Integrations in a library - [Alpakka](https://developer.lightbend.com/docs/alpakka/current/) - just turned [2 years](https://akka.io/blog/2016/08/23/intro-alpakka.html) the other day. 
+Akka's satellite project to collect Reactive Enterprise Integrations in a library - [Alpakka](https://doc.akka.io/docs/alpakka/current/) - just turned [2 years](https://akka.io/blog/2016/08/23/intro-alpakka.html) the other day. 
 
 In these 2 years Alpakka has grown from a handful of included technologies to a large set of Reactive Integrations built on Akka Streams, delivered in more than 30 modules.
 
@@ -21,7 +21,7 @@ As the community's efforts show the interest in creating an ecosystem for Reacti
 
 During these two years, the Alpakka modules have tried out different approaches and code layouts. A common API structure has evolved that fits most modules we've seen to date. 
 
-The [Alpakka team](https://akka.io/team/) at [Lightbend](https://www.lightbend.com/) has put together some [contributor advice](https://github.com/akka/alpakka/blob/master/contributor-advice.md) and recently implemented a [reference connector implementation](https://developer.lightbend.com/docs/alpakka/current/reference.html) to document and illustrate the recommended pattern for all Alpakka contributors.
+The [Alpakka team](https://akka.io/team/) at [Lightbend](https://www.lightbend.com/) has put together some [contributor advice](https://github.com/akka/alpakka/blob/master/contributor-advice.md) and recently implemented a [reference connector implementation](https://doc.akka.io/docs/alpakka/current/reference.html) to document and illustrate the recommended pattern for all Alpakka contributors.
 
 We've now started to change existing modules into this recommended structure, as we believe it will make it easier for all contributors to find their way through more than one module. 
 

--- a/blog/_posts/2019-03-19-akka-management-1.0.0-released.md
+++ b/blog/_posts/2019-03-19-akka-management-1.0.0-released.md
@@ -36,7 +36,7 @@ Beyond API stabilization, notable improvements include:
 * Various documentation improvements and more convenient default configuration
 
 For uses that are upgrading from earlier versions a 
-[migration guide](https://developer.lightbend.com/docs/akka-management/current/migration.html)
+[migration guide](https://doc.akka.io/docs/akka-management/current/migration.html)
 is available.
 
 – The Akka Team

--- a/blog/_posts/2019-04-03-akka-2.5.22-released.md
+++ b/blog/_posts/2019-04-03-akka-2.5.22-released.md
@@ -15,7 +15,7 @@ new Actor APIs (Akka Typed) and Artery ready for use in production, more about t
 An API for a distributed lease (lock) has been added to a new module called
 [Akka Coordination](https://doc.akka.io/docs/akka/current/coordination.html).
 The lease can be used with Cluster Sharding and Singleton, as well as Lightbend's 
-[Split Brain Resolver](https://developer.lightbend.com/docs/akka-commercial-addons/current/split-brain-resolver.html#lease)
+[Split Brain Resolver](https://doc.akka.io/docs/akka-enhancements/current/split-brain-resolver.html#lease)
 for additional additional safety measures for split brain scenarios. More details below.
 
 Some other notable improvements and bug fixes in 2.5.22 are:
@@ -82,11 +82,11 @@ is completely different. It will require a full cluster shutdown and new startup
 The distributed [lease](https://doc.akka.io/docs/akka/current/coordination.html#lease) can be used
 for additional additional safety measures for split brain scenarios in the following modules:
 
-* Lightbend's [Split Brain Resolver](https://developer.lightbend.com/docs/akka-commercial-addons/current/split-brain-resolver.html#lease). An additional safety measure so that only one SBR instance can make the decision to remain up.
+* Lightbend's [Split Brain Resolver](https://doc.akka.io/docs/akka-enhancements/current/split-brain-resolver.html#lease). An additional safety measure so that only one SBR instance can make the decision to remain up.
 * [Cluster Singleton](https://doc.akka.io/docs/akka/current/cluster-singleton.html#lease). A singleton manager can be configured to acquire a lease before creating the singleton.
 * [Cluster Sharding](https://doc.akka.io/docs/akka/current/cluster-sharding.html#lease). Each shard can be configured to acquire a lease before creating entity actors.
 
-An [implementation for Kubernetes](https://developer.lightbend.com/docs/akka-commercial-addons/current/kubernetes-lease.html)
+An [implementation for Kubernetes](https://doc.akka.io/docs/akka-enhancements/current/kubernetes-lease.html)
 is available for Lightbend customers.
 
 Note that [akka-coordination](https://doc.akka.io/docs/akka/current/coordination.html) is a new transitive dependency from

--- a/docs/index.html
+++ b/docs/index.html
@@ -430,7 +430,7 @@ redirect_from: "/downloads"
                <h2>Scala and Java</h2>
              </div>
              <div class="docMetaContent">
-               <a href="https://doc.akka.io/docs/alpakka/current/">Reference</a>
+               <a href="https://doc.akka.io/docs/alpakka/">Reference</a>
                <a href="https://github.com/akka/alpakka/">Repository</a>
              </div>
           </div>
@@ -446,7 +446,7 @@ redirect_from: "/downloads"
                <h2>Scala and Java</h2>
              </div>
              <div class="docMetaContent">
-               <a href="https://doc.akka.io/docs/alpakka-kafka/current/">Reference</a>
+               <a href="https://doc.akka.io/docs/alpakka-kafka/">Reference</a>
                <a href="https://github.com/akka/alpakka-kafka/">Repository</a>
              </div>
           </div>
@@ -466,7 +466,7 @@ redirect_from: "/downloads"
                       <h2>Scala and Java</h2>
                   </div>
                   <div class="docMetaContent">
-                      <a href="https://developer.lightbend.com/docs/akka-grpc/current/">Reference</a>
+                      <a href="https://doc.akka.io/docs/akka-grpc/">Reference</a>
                       <a href="https://github.com/akka/akka-grpc/">Repository</a>
                   </div>
               </div>
@@ -483,7 +483,7 @@ redirect_from: "/downloads"
                <h2>Scala and Java</h2>
              </div>
              <div class="docMetaContent">
-               <a href="https://developer.lightbend.com/docs/akka-commercial-addons/current/">Reference</a>
+               <a href="https://doc.akka.io/docs/akka-enhancements/">Reference</a>
                <a href="https://www.lightbend.com/subscription">Lightbend Subscription</a>
              </div>
           </div>
@@ -500,7 +500,7 @@ redirect_from: "/downloads"
                   <h2>Scala and Java</h2>
               </div>
               <div class="docMetaContent">
-                  <a href="https://developer.lightbend.com/docs/akka-management/current/">Reference</a>
+                  <a href="https://doc.akka.io/docs/akka-management/">Reference</a>
                   <a href="https://github.com/akka/akka-management/">Repository</a>
               </div>
           </div>

--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@ description: Build powerful reactive, concurrent, and distributed applications i
                             Asynchronous non-blocking stream processing with backpressure.
                             Fully async and streaming <a href="https://doc.akka.io/docs/akka-http/current/scala/http/introduction.html">HTTP server and client</a>
                             provides a great platform for building microservices.
-                            Streaming integrations with <a href="http://developer.lightbend.com/docs/alpakka/current/">Alpakka</a>.
+                            Streaming integrations with <a href="https://doc.akka.io/docs/alpakka/">Alpakka</a>.
                         </p>
                     </span>
                 </li>
@@ -135,7 +135,7 @@ description: Build powerful reactive, concurrent, and distributed applications i
                             Asynchronous non-blocking stream processing with backpressure.
                             Fully async and streaming <a href="https://doc.akka.io/docs/akka-http/current/scala/http/introduction.html">HTTP server and client</a>
                             provides a great platform for building microservices.
-                            Streaming integrations with <a href="http://developer.lightbend.com/docs/alpakka/current/">Alpakka</a>.
+                            Streaming integrations with <a href="https://doc.akka.io/docs/alpakka/current/">Alpakka</a>.
                         </p>
                     </span>
                 </li>


### PR DESCRIPTION
## Purpose

Let links point directly to the new home.

## References

https://github.com/akka/akka.github.com/issues/607
https://github.com/akka/akka.github.com/issues/568
https://github.com/akka/akka.github.com/issues/561

https://github.com/akka/akka-management/pull/553
https://github.com/akka/akka-grpc/pull/583
