### PR TITLE
Link to Akka Persistence Cassandra on akka.io

### DIFF
--- a/blog/_posts/2019-06-11-scala-2.13-landed-in-akka.md
+++ b/blog/_posts/2019-06-11-scala-2.13-landed-in-akka.md
@@ -21,7 +21,7 @@ We are pleased to announce that most members in the Akka family are available fo
 | [Akka Cluster Sharding](https://doc.akka.io/docs/akka/2.5/cluster-sharding.html) | | 2.5.23 |
 | [Akka Distributed Data](https://doc.akka.io/docs/akka/2.5/distributed-data.html) | | 2.5.23 |
 | [Akka Persistence](https://doc.akka.io/docs/akka/2.5/persistence.html) | | 2.5.23 |
-| [Akka Persistence Cassandra](https://github.com/akka/akka-persistence-cassandra/tree/release-0.x) | | 0.98 and 0.62 |
+| [Akka Persistence Cassandra](https://doc.akka.io/docs/akka-persistence-cassandra/0.98/) | | 0.98 and 0.62 |
 | [Akka HTTP](https://doc.akka.io/docs/akka-http/10.1/index.html) | | 10.1.8 |
 | [Akka Management](https://doc.akka.io/docs/akka-management/) | | 1.0.1 |
 | [Alpakka Kafka](https://doc.akka.io/docs/alpakka-kafka/current/) | | 1.0.4 |


### PR DESCRIPTION
## Purpose

Update the link to Akka Persistence Cassandra on the recent blog post so it points to the akka.io docs.