### PR TITLE
Presentations and blogs page

### DIFF
--- a/_data/presentations_blogs.yml
+++ b/_data/presentations_blogs.yml
@@ -1,3 +1,13 @@
+- title: Tour of Akka Typed
+  url: https://manuel.bernhardt.io/articles/#akka-typed
+  type: blog
+  tags:
+    - Actors
+    - Typed
+  author: by Manuel Bernhardt
+  content: In this series we are going to explore Akka Typed, the new Akka Actor API that brings significant advantage over the classic one. If you’re not familiar with the Akka Actor API, don’t worry — this series is intended to be understandable even if you do not. If you are familiar with the Actor API then this series will help you understand and learn how to work with Akka Typed.
+  date: 2019-07-11
+
 - title: Streaming data from Cassandra using Alpakka
   url: https://blog.knoldus.com/streaming-data-from-cassandra-using-alpakka/
   type: blog
@@ -8,7 +18,6 @@
   content: The Alpakka Cassandra connector allows us to read and write data from/to Cassandra tables. Using Alpakka CassandraSource we can read the data from Cassandra tables and similarly we can use CassandraFlow or CassandraSink.
   date: 2019-09-03
 
-
 - title: Reactive Integration with Akka Streams and Alpakka
   url: https://www.youtube.com/watch?v=gUNiEZG8cbM
   type: presentation
@@ -18,3 +27,12 @@
   content: An alpaca is like a camel, but is Alpakka like Apache Camel? Can we use the reactive approach in the area of integration as well, instead of the blocking approach that Camel usually offers? In this live coding session we’re going to explore the possibilities that Alpakka - a set of connectors for Akka Streams - offers to fetch data from various data sources and send it to different destinations. Using those, you’re going to learn, on a working example, how to build a reactive integration layer with the help of Akka Streams - one of the most popular Reactive Streams implementations. And if you thought Akka and friends were only for the Scala people, come to learn the nice Java APIs and see how wrong you were.
   date: 2019-05-15
 
+- title: Tour of Akka Cluster
+  url: https://manuel.bernhardt.io/articles/#akka-cluster
+  type: blog
+  tags:
+    - Actors
+    - Cluster
+  author: by Manuel Bernhardt
+  content: Building distributed systems is hard. Pesky things like the laws of physics get in the way of maintaining state accross geographically (and chronologically) disparate systems, and, if that weren’t already outrageous enough in itself, those systems may be subject to network failures, forcing us to think about annoying tradeoffs regarding consistency, availability and the meaning of life.
+  date: 2018-05-31

--- a/_data/presentations_blogs.yml
+++ b/_data/presentations_blogs.yml
@@ -1,0 +1,20 @@
+- title: Streaming data from Cassandra using Alpakka
+  url: https://blog.knoldus.com/streaming-data-from-cassandra-using-alpakka/
+  type: blog
+  tags:
+    - Alpakka
+    - Cassandra
+  author: by Girish Bharti
+  content: The Alpakka Cassandra connector allows us to read and write data from/to Cassandra tables. Using Alpakka CassandraSource we can read the data from Cassandra tables and similarly we can use CassandraFlow or CassandraSink.
+  date: 2019-09-03
+
+
+- title: Reactive Integration with Akka Streams and Alpakka
+  url: https://www.youtube.com/watch?v=gUNiEZG8cbM
+  type: presentation
+  tags:
+    - Alpakka
+  author: by Jacek Kunicki at GeeCON Kraków
+  content: An alpaca is like a camel, but is Alpakka like Apache Camel? Can we use the reactive approach in the area of integration as well, instead of the blocking approach that Camel usually offers? In this live coding session we’re going to explore the possibilities that Alpakka - a set of connectors for Akka Streams - offers to fetch data from various data sources and send it to different destinations. Using those, you’re going to learn, on a working example, how to build a reactive integration layer with the help of Akka Streams - one of the most popular Reactive Streams implementations. And if you thought Akka and friends were only for the Scala people, come to learn the nice Java APIs and see how wrong you were.
+  date: 2019-05-15
+

--- a/_includes/presentations-blogs-item.html
+++ b/_includes/presentations-blogs-item.html
@@ -1,0 +1,24 @@
+<li>
+    <a href="{{ p.url }}" alt="{{ p.title }}">
+        <div class="newsDate">
+            <p>{{ p.date | date: "%b" }}</p>
+            <p>{{ p.date | date: "%d" }}</p>
+            <p>{{ p.date | date: "%Y" }}</p>
+        </div>
+        {% if p.short %}
+        <div class="newsContent">
+            <h1>{{ p.title }}</h1>
+            <p>{{ p.author }}</p>
+            <p>{{ p.short }}</p>
+            <h3>Tags: {% for t in p.tags %}<span>{{t}} </span>{% endfor %}</h3>
+        </div>
+        {% else %}
+        <div class="newsContent">
+            <h1>{{ p.title }}</h1>
+            <p>{{ p.author }}</p>
+            <p>{{ p.content | strip_html | truncatewords: 30 }}</p>
+            <h3>Tags: {% for t in p.tags %}<span>{{t}} </span>{% endfor %}</h3>
+        </div>
+        {% endif %}
+    </a>
+</li>

--- a/presentations-blogs/index.md
+++ b/presentations-blogs/index.md
@@ -1,0 +1,35 @@
+---
+layout: page
+title: Presentations and Blogs
+---
+
+Many people have reported about their work with Akka in different forms. Find a few presentaions, blogs and articles below.
+
+<section class="wrapper indexLatest">
+    <div class="row">
+        <h1>Presentations</h1>
+    </div>
+    <div class="row">
+        <ul class="newsContainer">
+{% for p in site.data.presentations_blogs %}
+  {% if p.type contains "presentation" %}
+    {% include presentations-blogs-item.html %}
+  {% endif %}
+{% endfor %}
+        </ul>
+    </div>
+
+    <div class="row">
+        <h1>Blogs</h1>
+    </div>
+    <div class="row">
+        <ul class="newsContainer">
+{% for p in site.data.presentations_blogs %}
+  {% if p.type contains "blog" %}
+    {% include presentations-blogs-item.html %}
+  {% endif %}
+{% endfor %}
+        </ul>
+    </div>
+
+</section>

--- a/presentations-blogs/index.md
+++ b/presentations-blogs/index.md
@@ -3,7 +3,9 @@ layout: page
 title: Presentations and Blogs
 ---
 
-Many people have reported about their work with Akka in different forms. Find a few presentaions, blogs and articles below.
+Let's learn from each other! Many people have shared their experiences with Akka in presentations, blogs and webcasts. We've collected a few presentations and blogs below.
+
+Feel free to suggest additions to this list. A great way to do that is by sharing a link to it in the [Akka forum](https://discuss.akka.io).
 
 <section class="wrapper indexLatest">
     <div class="row">


### PR DESCRIPTION
## Purpose

Add a page where presentations and blogs can be referenced.
It is not referenced from any other page until we collect a useful amount of entries for it.

## Background Context

In Alpakka we have [Webinars, Presentations and Articles](https://doc.akka.io/docs/alpakka/current/other-docs/webinars-presentations-articles.html). It would be great if we create a central place for external resources that get collected over time.