### PR TITLE
update version and docs index to Akka 2.6.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -31,7 +31,7 @@ defaults:
     # note that changing this requires a jekyll restart to be picked up if serving locally
     # versions.json will be updated as long as the changes here are patch versions, for minor and major it needs to
     # be updated manually
-    current_akka_version: 2.5.26
+    current_akka_version: 2.6.0
     current_akka_http_version: 10.1.10
-    previous_akka_version: 2.4.20
+    previous_akka_version: 2.5.26
     current_java_scala_version: 2.12 # used for deps for Java

--- a/docs/index.html
+++ b/docs/index.html
@@ -72,9 +72,9 @@ redirect_from: "/downloads"
                <h2>Scala and Java</h2>
            </div>
            <div class="docMetaContent">
-             <a href="https://doc.akka.io/docs/akka/current/index-actors.html">Reference</a>
-             <a href="https://doc.akka.io/api/akka/current/akka/actor/index.html">Scala API</a>
-             <a href="https://doc.akka.io/japi/akka/current/index.html?akka/actor/package-summary.html">Java API</a>
+             <a href="https://doc.akka.io/docs/akka/current/typed/index.html">Reference</a>
+             <a href="https://doc.akka.io/api/akka/current/akka/actor/typed/scaladsl/index.html">Scala API</a>
+             <a href="https://doc.akka.io/japi/akka/current/index.html?akka/actor/typed/javadsl/package-summary.html">Java API</a>
            </div>
          </div>
       </div>
@@ -136,9 +136,9 @@ redirect_from: "/downloads"
                 <h2>Scala and Java</h2>
             </div>
           <div class="docMetaContent">
-            <a href="https://doc.akka.io/docs/akka/current/cluster-usage.html">Reference</a>
-            <a href="https://doc.akka.io/api/akka/current/akka/cluster/index.html">Scala API</a>
-            <a href="https://doc.akka.io/japi/akka/current/index.html?akka/cluster/package-summary.html">Java API</a>
+            <a href="https://doc.akka.io/docs/akka/current/typed/cluster.html">Reference</a>
+            <a href="https://doc.akka.io/api/akka/current/akka/cluster/typed/index.html">Scala API</a>
+            <a href="https://doc.akka.io/japi/akka/current/index.html?akka/cluster/typed/package-summary.html">Java API</a>
           </div>
         </div>
       </div>
@@ -156,9 +156,9 @@ redirect_from: "/downloads"
                 <h2>Scala and Java</h2>
             </div>
           <div class="docMetaContent">
-            <a href="https://doc.akka.io/docs/akka/current/cluster-sharding.html">Reference</a>
-            <a href="https://doc.akka.io/api/akka/current/akka/cluster/sharding/index.html">Scala API</a>
-            <a href="https://doc.akka.io/japi/akka/current/index.html?akka/cluster/sharding/package-summary.html">Java API</a>
+            <a href="https://doc.akka.io/docs/akka/current/typed/cluster-sharding.html">Reference</a>
+            <a href="https://doc.akka.io/api/akka/current/akka/cluster/sharding/typed/scaladsl/index.html">Scala API</a>
+            <a href="https://doc.akka.io/japi/akka/current/index.html?akka/cluster/sharding/typed/javadsl/package-summary.html">Java API</a>
           </div>
         </div>
       </div>
@@ -176,9 +176,9 @@ redirect_from: "/downloads"
                 <h2>Scala and Java</h2>
             </div>
           <div class="docMetaContent">
-              <a href="https://doc.akka.io/docs/akka/current/distributed-data.html">Reference</a>
-               <a href="https://doc.akka.io/api/akka/current/akka/cluster/ddata/index.html">Scala API</a>
-               <a href="https://doc.akka.io/japi/akka/current/index.html?akka/cluster/ddata/package-summary.html">Java API</a>
+              <a href="https://doc.akka.io/docs/akka/current/typed/distributed-data.html">Reference</a>
+               <a href="https://doc.akka.io/api/akka/current/akka/cluster/ddata/typed/scaladsl/index.html">Scala API</a>
+               <a href="https://doc.akka.io/japi/akka/current/index.html?akka/cluster/ddata/typed/javadsl/package-summary.html">Java API</a>
              </div>
            </div>
         </div>
@@ -200,9 +200,9 @@ redirect_from: "/downloads"
                 <h2>Scala and Java</h2>
               </div>
               <div class="docMetaContent">
-              <a href="https://doc.akka.io/docs/akka/current/persistence.html">Reference</a>
-              <a href="https://doc.akka.io/api/akka/current/akka/persistence/index.html">Scala API</a>
-              <a href="https://doc.akka.io/japi/akka/current/index.html?akka/persistence/package-summary.html">Java API</a>
+              <a href="https://doc.akka.io/docs/akka/current/typed/persistence.html">Reference</a>
+              <a href="https://doc.akka.io/api/akka/current/akka/persistence/typed/scaladsl/index.html">Scala API</a>
+              <a href="https://doc.akka.io/japi/akka/current/index.html?akka/persistence/typed/javadsl/package-summary.html">Java API</a>
             </div>
           </div>
         </div>

--- a/docs/other-releases.md
+++ b/docs/other-releases.md
@@ -9,16 +9,28 @@ For current stable release ({{page.current_akka_version}}) check the [documentat
 Snapshots of the latest development version of Akka docs are available 
 
 Documentation:
-[Java Manual](https://doc.akka.io/docs/akka/snapshot/java/)
+[Java Manual](https://doc.akka.io/docs/akka/snapshot/index.html?language=java)
 [Java API](https://doc.akka.io/japi/akka/snapshot/)
-[Scala Manual](https://doc.akka.io/docs/akka/snapshot/scala/)
+[Scala Manual](https://doc.akka.io/docs/akka/snapshot/index.html?language=scala)
 [Scala API](https://doc.akka.io/api/akka/snapshot/)
 
 ## Archive
 
 ### Akka {{ page.previous_akka_version }}
 
-Akka 2.4 was the previous stable version. Unsupported, only patched if critical bugs are found.
+Akka 2.5 was the previous stable version. Only patched if critical bugs are found.
+
+Documentation:
+[Java Manual](https://doc.akka.io/docs/akka/current/index.html?language=java)
+[Java API](https://doc.akka.io/japi/akka/2.4)
+[Scala Manual](https://doc.akka.io/docs/akka/current/index.html?language=scala)
+[Scala API](https://doc.akka.io/api/akka/2.4)
+
+Artifacts are available from Maven Central.
+
+### Akka 2.4
+
+Akka 2.4 reached end-of-life 12/31/2017, with the last version being 2.4.20
 
 Documentation:
 [Java Manual](https://doc.akka.io/docs/akka/2.4/java.html)


### PR DESCRIPTION
To be merged after switching the `current` symlinks