### PR TITLE
Videos only get embedded in the blog if cookies have been approved

### DIFF
--- a/_includes/headerbottom.html
+++ b/_includes/headerbottom.html
@@ -1,15 +1,7 @@
     <!-- OneTrust Cookies Consent Notice (Production Standard, akka.io, en-GB) start -->
     <script src="https://optanon.blob.core.windows.net/consent/159bb13d-6748-4399-806e-ac28db879785.js" type="text/javascript" charset="UTF-8"></script> 
-    <script type="text/javascript">
-      function OptanonWrapper() {
-        //oneTrust callback, once code has loaded and init 
-      }
-    </script>
     <!-- OneTrust Cookies Consent Notice (Production Standard, akka.io, en-GB) end -->
-
-
-
-
+    
     <!--Google Analytics & Google Tag Manager-->
     <script type="text/plain" class="optanon-category-2">
     

--- a/_includes/youtubePlayer.html
+++ b/_includes/youtubePlayer.html
@@ -1,3 +1,3 @@
-<div class="tubeytube">
-  <iframe src="https://www.youtube.com/embed/{{ include.id }}" frameborder="0" allow="fullscreen"></iframe>
+<div class="yt-widget" id="yt-{{ include.id }}">
+	<a href="https://www.youtube.com/watch?v={{ include.id }}" target="_blank" >Watch the video on YouTube</a>
 </div>

--- a/resources/javascript/akka-io.js
+++ b/resources/javascript/akka-io.js
@@ -1,5 +1,7 @@
 $(function () {
 
+
+
     // algolia search box hook
 
     // initalizes doc search if there is a search box
@@ -94,3 +96,17 @@ $(function () {
     })
 
 });
+
+//oneTrust callback, once code has loaded and init
+function OptanonWrapper() {
+    //find all YouTube Widgets on the page
+    $( ".yt-widget" ).each(function( index ) {
+        var widget = $(this);
+        //remove the prepended yt- from the ID. The ID is prepended with yt- so that we don't break old html4 clients that can't have IDs that begin with numbers.
+        var ytID = widget.attr("id").slice(3);
+        //swap out link with allow cookies dialogue
+        widget.html('<div class="cookie-warning video-warning"><p>To watch this video in page.<a class="optanon-allow-all">Allow Cookies</a><br><small>Alternatively you can <a class="link" href="https://www.youtube.com/watch?v='+ytID+'" target="_blank">watch on YouTube</a>.</small></p></div>');
+        //load youtube player if cookies are approved
+        Optanon.InsertHtml('<div class="tubeytube"><iframe src="//www.youtube.com/embed/'+ytID+'?rel=0&modestbranding=0" frameborder="0" allow="fullscreen"></iframe></div>', 'yt-'+ytID, null, {deleteSelectorContent: true}, 4);
+    }); 
+};

--- a/resources/stylesheets/sass/modules/_oneTrust.scss
+++ b/resources/stylesheets/sass/modules/_oneTrust.scss
@@ -49,18 +49,51 @@ body .optanon-alert-box-wrapper .optanon-alert-box-bottom-padding {
 			display: inline-block;
 			padding: .25rem .5rem;
 			text-decoration: none;
-			margin: .25rem 1rem;
+			margin: .25rem .5rem;
 			cursor: pointer;
 			&:hover {
 				background: rgba(white, .6);
 				color: #6cc04a;
 			}
 		}
+		> a.link {
+			border: none;
+			color: white;
+			display: inline;
+			padding: 0;
+			text-decoration: underline;
+			margin: 0;
+			cursor: pointer;
+			&:hover {
+				background: none;
+				color: white;
+			}
+		}
 	}
 	small {
 		color: white !important;
-		font-size: .875rem !important;
+		font-size: .75rem !important;
+		margin-top: .5rem;
+		display: inline-block;
+		opacity: .9;
+		> a.link {
+			border: none;
+			color: white;
+			display: inline;
+			padding: 0;
+			text-decoration: underline;
+			font-size: .75rem !important;
+			margin: 0;
+			cursor: pointer;
+			&:hover {
+				background: none;
+				color: #366025;
+			}
+		}
 	}
+}
+.cookie-warning.video-warning{
+	text-align: left;
 }
 .flex-video {
 	background-color: lb-off-white-dkr;


### PR DESCRIPTION
## Purpose

Have YouTube embedded players respect privacy policy.

## Changes

The Author continues to add videos in exactly the same way as before, the code now inserts a link to the video on YouTube when the page first loads. This is the first fallback incase JavaScript doesn't load, throws errors etc. Most users should never see this.

![no-javascript-or-an-error](https://user-images.githubusercontent.com/1418129/73484749-b7e97400-4356-11ea-9d80-92a6ec1a7162.png)


Once the cookie compliance code loads, it swaps out the original link with an accept cookies dialogue. This dialogue also provides a link to the YouTube video for those that might not wish to accept cookies. 

![cookie-approval-needed](https://user-images.githubusercontent.com/1418129/73484937-0dbe1c00-4357-11ea-8e5a-9ba21c623d12.png)


Once cookies have been accepted the video loads. You only have to accept cookies once on the site, so for regular visitors they will likely just see the video. 

![video-loads](https://user-images.githubusercontent.com/1418129/73485705-76f25f00-4358-11ea-81af-13163797bcb1.png)



To test locally, you need to add `-test.js` to the end of the OneTrust JS include:

`https://optanon.blob.core.windows.net/consent/159bb13d-6748-4399-806e-ac28db879785-test.js` which can be found here:  `_includes/headerbottom.html`

You then need to go into the Cookie Setting dialogue and turn Targeting Cookies on and off to see the different experiences.  

![cookie-settings](https://user-images.githubusercontent.com/1418129/73489803-17984d00-4360-11ea-8093-f4d48add33e9.png)


